### PR TITLE
Mac OS Changes

### DIFF
--- a/protege-distribution/src/main/assembly/protege-as-directory.xml
+++ b/protege-distribution/src/main/assembly/protege-as-directory.xml
@@ -1,104 +1,109 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-	
-	<id>bin</id>
-	<formats>
-		<format>dir</format>
-	</formats>
-	<baseDirectory>Protege</baseDirectory>
-	
-	<fileSets>
-		<fileSet>
-			<outputDirectory>.</outputDirectory>
-			<includes>
-				<include>*</include>
-			</includes>
-			<excludes>
-				<exclude>run.command</exclude>
-				<exclude>run.sh</exclude>
-			</excludes>
-			<directory>src/main/config/distributions/felix</directory>
-		</fileSet>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
-		<fileSet>
-			<outputDirectory>bin</outputDirectory>
-			<includes>
-				<include>*</include>
-			</includes>
-			<directory>src/main/config/distributions/felix/bin</directory>
-		</fileSet>
+    <id>bin</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <baseDirectory>Protege</baseDirectory>
 
-		<fileSet>
-			<outputDirectory>bundles</outputDirectory>
-			<includes>
-				<include>org.apache.felix.bundlerepository-1.4.2.jar</include>
-			</includes>
-			<directory>src/main/config/distributions/felix/bundles</directory>
-		</fileSet>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <excludes>
+                <exclude>run.command</exclude>
+                <exclude>run.sh</exclude>
+            </excludes>
+            <directory>src/main/config/distributions/felix</directory>
+        </fileSet>
 
-		<fileSet>
-			<outputDirectory>bundles</outputDirectory>
-			<includes>
-				<include>*.jar</include>
-			</includes>
-			<directory>src/main/config/distributions/common</directory>
-		</fileSet>
-	</fileSets>
+        <fileSet>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <directory>src/main/config/distributions/felix/bin</directory>
+        </fileSet>
 
-	<files>
-		<file>
-			<source>src/main/config/distributions/felix/run.sh</source>
-			<outputDirectory>.</outputDirectory>
-			<fileMode>744</fileMode>
-		</file>
-		<file>
-			<source>src/main/config/distributions/felix/run.command</source>
-			<outputDirectory>.</outputDirectory>
-			<fileMode>744</fileMode>
-		</file>
-	</files>
-	
-	<dependencySets>
-		<dependencySet>
-			<outputDirectory>bin</outputDirectory>
-			<includes>
-				<include>edu.stanford.protege:ProtegeLauncher:jar</include>
-			</includes>
-			<useStrictFiltering>true</useStrictFiltering>
-			<outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-		</dependencySet>
-	
-		<dependencySet>
-			<outputDirectory>bundles</outputDirectory>
-			<includes>
-				<include>edu.stanford.protege:org.protege.common:jar</include>
-				<include>edu.stanford.protege:org.protege.editor.core.application:jar</include>
-			</includes>
-			<useStrictFiltering>true</useStrictFiltering>
-			<outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-		</dependencySet>
-		
-		<dependencySet>
-			<outputDirectory>plugins</outputDirectory>
-			<includes>
-				<include>edu.stanford.protege:ca.uvic.cs.chisel.cajun:jar</include>
-				<include>edu.stanford.protege:org.coode.dlquery:jar</include>
-				<include>edu.stanford.protege:org.coode.owlviz:jar</include>
-				<include>edu.stanford.protege:org.protege.editor.owl:jar</include>
-				<include>edu.stanford.protege:org.protege.editor.owl.client:jar</include>
-				<include>edu.stanford.protege:org.protege.editor.owl.codegeneration:jar</include>
-				<include>edu.stanford.protege:org.protege.editor.owl.diff:jar</include>
-				<include>edu.stanford.protege:org.protege.editor.owl.rdf:jar</include>
-				<!-- <include>edu.stanford.protege:org.protege.explanation:jar</include> -->
-				<include>edu.stanford.protege:org.protege.integration.hermit:jar</include>
-				<include>edu.stanford.protege:org.protege.ontograf:jar</include>
-				<include>edu.stanford.protege:org.protege.owl.diff:jar</include>
-				<include>edu.stanford.protege:org.protege.owl.rdf:jar</include>
-				<include>edu.stanford.protege:org.protege.owl.server:jar</include>
-				<include>net.sourceforge.owlapi:owlapi-distribution:jar</include>
-			</includes>
-			<useStrictFiltering>true</useStrictFiltering>
-			<outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-		</dependencySet>
+        <fileSet>
+            <outputDirectory>bundles</outputDirectory>
+            <includes>
+                <include>org.apache.felix.bundlerepository-1.4.2.jar</include>
+            </includes>
+            <directory>src/main/config/distributions/felix/bundles</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>bundles</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <directory>src/main/config/distributions/common</directory>
+        </fileSet>
+    </fileSets>
+
+    <files>
+        <file>
+            <source>src/main/config/distributions/felix/run.sh</source>
+            <outputDirectory>.</outputDirectory>
+            <fileMode>744</fileMode>
+        </file>
+        <file>
+            <source>src/main/config/distributions/felix/run.command</source>
+            <outputDirectory>.</outputDirectory>
+            <fileMode>744</fileMode>
+        </file>
+        <file>
+            <source>src/main/config/distributions/Protege.app/Contents/Resources/Protege.icns</source>
+            <outputDirectory>.</outputDirectory>
+        </file>
+    </files>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>edu.stanford.protege:ProtegeLauncher:jar</include>
+            </includes>
+            <useStrictFiltering>true</useStrictFiltering>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+        </dependencySet>
+
+        <dependencySet>
+            <outputDirectory>bundles</outputDirectory>
+            <includes>
+                <include>edu.stanford.protege:org.protege.common:jar</include>
+                <include>edu.stanford.protege:org.protege.editor.core.application:jar</include>
+            </includes>
+            <useStrictFiltering>true</useStrictFiltering>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+        </dependencySet>
+
+        <dependencySet>
+            <outputDirectory>plugins</outputDirectory>
+            <includes>
+                <include>edu.stanford.protege:ca.uvic.cs.chisel.cajun:jar</include>
+                <include>edu.stanford.protege:org.coode.dlquery:jar</include>
+                <include>edu.stanford.protege:org.coode.owlviz:jar</include>
+                <include>edu.stanford.protege:org.protege.editor.owl:jar</include>
+                <include>edu.stanford.protege:org.protege.editor.owl.client:jar</include>
+                <include>edu.stanford.protege:org.protege.editor.owl.codegeneration:jar</include>
+                <include>edu.stanford.protege:org.protege.editor.owl.diff:jar</include>
+                <include>edu.stanford.protege:org.protege.editor.owl.rdf:jar</include>
+                <!-- <include>edu.stanford.protege:org.protege.explanation:jar</include> -->
+                <include>edu.stanford.protege:org.protege.integration.hermit:jar</include>
+                <include>edu.stanford.protege:org.protege.ontograf:jar</include>
+                <include>edu.stanford.protege:org.protege.owl.diff:jar</include>
+                <include>edu.stanford.protege:org.protege.owl.rdf:jar</include>
+                <include>edu.stanford.protege:org.protege.owl.server:jar</include>
+                <include>net.sourceforge.owlapi:owlapi-distribution:jar</include>
+            </includes>
+            <useStrictFiltering>true</useStrictFiltering>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+        </dependencySet>
     </dependencySets>
 </assembly>

--- a/protege-distribution/src/main/config/distributions/felix/run.command
+++ b/protege-distribution/src/main/config/distributions/felix/run.command
@@ -1,2 +1,2 @@
 cd `dirname $0`
-CMD_OPTIONS="-Dapple.laf.useScreenMenuBar=true -Xdock:name=Protege" sh run.sh
+CMD_OPTIONS="-Dapple.laf.useScreenMenuBar=true -Dcom.apple.mrj.application.apple.menu.about.name=Protege  -Xdock:name=Protege -Xdock:icon=Protege.icns -Xdock:name=Protege" sh run.sh

--- a/protege-distribution/src/main/config/distributions/felix/run.sh
+++ b/protege-distribution/src/main/config/distributions/felix/run.sh
@@ -8,4 +8,4 @@ java -Xmx500M -Xms250M \
      -DentityExpansionLimit=100000000 \
      -Dfile.encoding=UTF-8 \
      -classpath bin/felix.jar:bin/ProtegeLauncher.jar \
-     org.protege.osgi.framework.Launcher
+     $CMD_OPTIONS org.protege.osgi.framework.Launcher


### PR DESCRIPTION
A few changes to make launching protege 5 from run.command work a bit better
use options from run.command in run.sh.
Set icon and application name correctly.
