### PR TITLE
Allow org.protege.editor.owl to build using  owlapi 3 5 1

### DIFF
--- a/org.protege.common/pom.xml
+++ b/org.protege.common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.stanford.protege</groupId>
 		<artifactId>protege-parent</artifactId>
-		<version>5.0.0-beta-16-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT-beta-16</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/org.protege.editor.core.application/pom.xml
+++ b/org.protege.editor.core.application/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.stanford.protege</groupId>
 		<artifactId>protege-parent</artifactId>
-		<version>5.0.0-beta-16-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT-beta-16</version>
 		<relativePath>../</relativePath>
 	</parent>
 	
@@ -63,17 +63,17 @@
 						</Import-Package>
 						<Include-Resource>plugin.xml,{maven-resources}</Include-Resource>
 					</instructions>
-					<executions>
-						<execution>
-							<id>bundle-manifest</id>
-							<phase>install</phase>
-							<goals>    
-								<goal>manifest</goal>
-							</goals>   
-						</execution>
-					</executions>
 				</configuration>
-			</plugin>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 				
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/org.protege.editor.owl/pom.xml
+++ b/org.protege.editor.owl/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>protege-owlapi-extensions</artifactId>
-            <version>3.2.6</version>
+            <version>[3.2.6,3.3-SNAPSHOT)</version>
         </dependency>
 
         <dependency>

--- a/org.protege.editor.owl/pom.xml
+++ b/org.protege.editor.owl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.stanford.protege</groupId>
         <artifactId>protege-parent</artifactId>
-        <version>5.0.0-beta-16-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT-beta-16</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>org.protege.xmlcatalog</artifactId>
-            <version>1.0.4</version>
+            <version>[1.0.4,2)</version>
         </dependency>
 
         <dependency>
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>[4,5)</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -94,7 +94,8 @@
                         <Embed-Dependency>protege-owlapi-extensions, org.protege.xmlcatalog</Embed-Dependency>
                         <Export-Package>
                             ${project.artifactId}*;version=${project.version},
-                            org.protege.xmlcatalog.*
+                            org.protege.xmlcatalog.*,
+                            org.protege.owlapi.model
                         </Export-Package>
                         <Import-Package>
                             org.eclipse.core.runtime;registry=split,

--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/repository/extractors/RdfExtractorConsumer.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/repository/extractors/RdfExtractorConsumer.java
@@ -1,15 +1,15 @@
 package org.protege.editor.owl.model.repository.extractors;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyID;
 import org.semanticweb.owlapi.rdf.syntax.RDFConsumer;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 import org.xml.sax.SAXException;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class RdfExtractorConsumer implements RDFConsumer {
     private Set<String> ontologyProperties        = new HashSet<String>();
@@ -82,6 +82,43 @@ public class RdfExtractorConsumer implements RDFConsumer {
     }
 
     public void startModel(String physicalURI) throws SAXException {
+
+    }
+
+    /**
+     * for iris that need to be mapped to blank nodes, e.g., SWRL rules with an
+     * IRI - the IRI should be dropped for such constructs.
+     *
+     * @param i iri to remap if not blank
+     * @return blank iri remapping i
+     */
+    @Override
+    public IRI remapIRI(IRI i) {
+        return null;
+    }
+
+    /**
+     * for iris that have been remapped to blank nodes, e.g., SWRL rules: the
+     * triple subject swrl:body object, for example, needs the subject to be
+     * remapped consistently.
+     *
+     * @param i iri to remap if not blank
+     * @return blank iri remapping i, or i if i has not been remapped earlier.
+     */
+    @Override
+    public String remapOnlyIfRemapped(String i) {
+        return i;
+    }
+
+    /**
+     * Add a prefix to the underlying ontology format, if prefixes are
+     * supported.
+     *
+     * @param abbreviation short name for prefix
+     * @param value
+     */
+    @Override
+    public void addPrefix(String abbreviation, String value) {
 
     }
 

--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/ui/error/OntologyLoadErrorHandlerUI.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/ui/error/OntologyLoadErrorHandlerUI.java
@@ -1,49 +1,32 @@
 package org.protege.editor.owl.ui.error;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
-import javax.swing.border.EmptyBorder;
-
+import de.uulm.ecs.ai.owlapi.krssparser.KRSS2OWLParser;
+import de.uulm.ecs.ai.owlapi.krssparser.KRSS2OntologyFormat;
 import org.apache.log4j.Logger;
 import org.coode.owlapi.functionalparser.OWLFunctionalSyntaxParser;
 import org.coode.owlapi.manchesterowlsyntax.ManchesterOWLSyntaxOntologyFormat;
 import org.coode.owlapi.manchesterowlsyntax.ManchesterOWLSyntaxOntologyParser;
 import org.coode.owlapi.obo.parser.OBOOntologyFormat;
-import org.coode.owlapi.obo.parser.OBOParser;
-import org.coode.owlapi.obo.parser.OBOParserException;
 import org.coode.owlapi.owlxmlparser.OWLXMLParser;
 import org.coode.owlapi.rdfxml.parser.RDFXMLParser;
 import org.coode.owlapi.turtle.TurtleOntologyFormat;
-import org.protege.editor.core.ProtegeApplication;
 import org.protege.editor.core.ui.error.ErrorExplainer;
 import org.protege.editor.core.ui.util.JOptionPaneEx;
 import org.protege.editor.owl.OWLEditorKit;
 import org.semanticweb.owlapi.expression.ParserException;
-import org.semanticweb.owlapi.io.OWLFunctionalSyntaxOntologyFormat;
-import org.semanticweb.owlapi.io.OWLParser;
-import org.semanticweb.owlapi.io.OWLParserException;
-import org.semanticweb.owlapi.io.OWLXMLOntologyFormat;
-import org.semanticweb.owlapi.io.RDFXMLOntologyFormat;
-import org.semanticweb.owlapi.io.UnparsableOntologyException;
+import org.semanticweb.owlapi.io.*;
 import org.semanticweb.owlapi.model.OWLOntologyFormat;
 import org.semanticweb.owlapi.model.OWLOntologyID;
+import org.semanticweb.owlapi.oboformat.OBOFormatOWLAPIParser;
 import org.semanticweb.owlapi.rdf.syntax.RDFParserException;
-
 import uk.ac.manchester.cs.owl.owlapi.turtle.parser.TurtleParser;
-import de.uulm.ecs.ai.owlapi.krssparser.KRSS2OWLParser;
-import de.uulm.ecs.ai.owlapi.krssparser.KRSS2OntologyFormat;
+
+import javax.swing.*;
+import java.awt.*;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Author: drummond<br>
@@ -143,7 +126,6 @@ public class OntologyLoadErrorHandlerUI implements OntologyLoadErrorHandler {
             }
         };
         errorFilter.addExplanationFactory(OWLParserException.class, owlParserExceptionExplanationFac);
-        errorFilter.addExplanationFactory(OBOParserException.class, owlParserExceptionExplanationFac);
 
         // Manchester Syntax
         errorFilter.addExplanationFactory(ParserException.class, new ErrorExplainer.ErrorExplanationFactory<ParserException>(){
@@ -173,7 +155,7 @@ public class OntologyLoadErrorHandlerUI implements OntologyLoadErrorHandler {
             format2ParserMap.put(TurtleOntologyFormat.class, TurtleParser.class.getSimpleName());
             format2ParserMap.put(OWLFunctionalSyntaxOntologyFormat.class, OWLFunctionalSyntaxParser.class.getSimpleName());
             format2ParserMap.put(KRSS2OntologyFormat.class, KRSS2OWLParser.class.getSimpleName());
-            format2ParserMap.put(OBOOntologyFormat.class, OBOParser.class.getSimpleName());
+            format2ParserMap.put(OBOOntologyFormat.class, OBOFormatOWLAPIParser.class.getSimpleName());
 
 
             tabs = new JTabbedPane();

--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/ui/metrics/DLMetricsViewComponent.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/ui/metrics/DLMetricsViewComponent.java
@@ -6,7 +6,6 @@ import org.protege.editor.owl.model.event.EventType;
 import org.protege.editor.owl.model.event.OWLModelManagerChangeEvent;
 import org.protege.editor.owl.model.event.OWLModelManagerListener;
 import org.protege.editor.owl.ui.view.AbstractOWLViewComponent;
-import org.semanticweb.owlapi.model.OWLException;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.OWLOntologyChangeListener;
 import org.semanticweb.owlapi.util.DLExpressivityChecker;
@@ -99,7 +98,7 @@ public class DLMetricsViewComponent extends AbstractOWLViewComponent {
             DLExpressivityChecker checker = new DLExpressivityChecker(getOWLModelManager().getActiveOntologies());
             namePanel.setConstructs(checker.getConstructs());
         }
-        catch (OWLException e) {
+        catch (Exception e) {
             logger.error(e);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>edu.stanford.protege</groupId>
     <artifactId>protege-parent</artifactId>
-    <version>5.0.0-beta-16-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT-beta-16</version>
     <packaging>pom</packaging>
 
     <name>Protege Desktop</name>

--- a/protege-base/pom.xml
+++ b/protege-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.stanford.protege</groupId>
 		<artifactId>protege-parent</artifactId>
-		<version>5.0.0-beta-16-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT-beta-16</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/protege-distribution/pom.xml
+++ b/protege-distribution/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>edu.stanford.protege</groupId>
 		<artifactId>protege-parent</artifactId>
-		<version>5.0.0-beta-16-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT-beta-16</version>
 		<relativePath>../</relativePath>
 	</parent>
 	
@@ -35,25 +35,25 @@
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-osgidistribution</artifactId>
-            <version>3.5.1</version>
+            <version>[3.5.1,3.9)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>ca.uvic.cs.chisel.cajun</artifactId>
-			<version>1.0.2</version>
+			<version>[1.0.2,2)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.coode.dlquery</artifactId>
-			<version>1.1.4</version>
+			<version>[1.1.4,2)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.coode.owlviz</artifactId>
-			<version>4.1.4</version>
+			<version>[4.1.4,5)</version>
         </dependency>
 
         <dependency>
@@ -77,49 +77,49 @@
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.editor.owl.codegeneration</artifactId>
-			<version>1.0.2</version>
+			<version>[1.0.2,2)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.editor.owl.diff</artifactId>
-			<version>4.1.1</version>
+			<version>[4.1.1,5)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.editor.owl.rdf</artifactId>
-			<version>1.0.0</version>
+			<version>[1.0.0,2)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.explanation</artifactId>
-			<version>1.0.0</version>
+			<version>[1.0.0,2)</version>
         </dependency>
         
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.integration.hermit</artifactId>
-			<version>1.0.0</version>
+			<version>[1.0.0,2)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.ontograf</artifactId>
-			<version>1.0.3</version>
+			<version>[1.0.3,2)</version>
         </dependency>
 
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.owl.diff</artifactId>
-			<version>1.0.1</version>
+			<version>[1.0.1,2)</version>
         </dependency>
         
         <dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.owl.rdf</artifactId>
-			<version>1.0.2</version>
+			<version>[1.0.2,2)</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
A reasonable idea, since 3.5.1 is used at run time.  

protege-owlapi-extions:3.2.7 has not been released to maven central, so I'm having to use a local copy.