### PR TITLE
Addressing #128

### DIFF
--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/hierarchy/cls/InferredOWLClassHierarchyProvider.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/hierarchy/cls/InferredOWLClassHierarchyProvider.java
@@ -63,37 +63,6 @@ public class InferredOWLClassHierarchyProvider extends AbstractOWLObjectHierarch
             }
         }
     };
-    private OWLOntologyChangeListener owlOntologyChangeListener = new OWLOntologyChangeListener() {
-    	public void ontologiesChanged(List<? extends OWLOntologyChange> changes) throws OWLException {
-    		OWLReasoner reasoner = owlModelManager.getReasoner();
-    		// the reasoner may not know it has updates yet - but we can check if it believes it will handle them
-    		if (!(reasoner instanceof NoOpReasoner) && reasoner.getBufferingMode() == BufferingMode.NON_BUFFERING) {
-    			boolean needsRefresh = false;
-    			for (OWLOntologyChange change : changes) {
-    				if (change instanceof OWLAxiomChange && ((OWLAxiomChange) change).getAxiom().isLogicalAxiom()) {
-    					needsRefresh = true;
-    					break;
-    				}
-    			}
-    			if (needsRefresh) {
-    				// too tricky... too tricky... wait until after the reasoner has reacted to the changes.
-    				SwingUtilities.invokeLater(new Runnable() {
-    					public void run() {
-    						try {
-    							if (owlModelManager.getOWLReasonerManager().getReasonerStatus() == ReasonerStatus.INITIALIZED) {
-    								fireHierarchyChanged();
-    							}
-    						}
-    						catch (ReasonerDiedException rde) {
-    							ReasonerUtilities.warnThatReasonerDied(null, rde);
-    						}
-    					}
-    				});
-    			}
-    		}
-    	}
-    };
-
 
     public InferredOWLClassHierarchyProvider(OWLModelManager owlModelManager, OWLOntologyManager owlOntologyManager) {
         super(owlOntologyManager);
@@ -103,7 +72,6 @@ public class InferredOWLClassHierarchyProvider extends AbstractOWLObjectHierarch
         owlNothing = owlModelManager.getOWLDataFactory().getOWLNothing();
 
         owlModelManager.addListener(owlModelManagerListener);
-        owlOntologyManager.addOntologyChangeListener(owlOntologyChangeListener);
     }
 
 
@@ -114,7 +82,6 @@ public class InferredOWLClassHierarchyProvider extends AbstractOWLObjectHierarch
     public void dispose() {
         super.dispose();
         owlModelManager.removeListener(owlModelManagerListener);
-        owlModelManager.getOWLOntologyManager().removeOntologyChangeListener(owlOntologyChangeListener);
     }
 
 

--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/ui/tree/OWLObjectTree.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/ui/tree/OWLObjectTree.java
@@ -258,15 +258,17 @@ public class OWLObjectTree<N extends OWLObject> extends JTree implements OWLObje
 
     /**
      * Causes the tree to be reloaded.  Note that this will collapse
-     * all expanded paths.
+     * all expanded paths except for the current selection.
      */
     public void reload() {
+    	N currentSelection = getSelectedOWLObject();    	
         // Reload the tree
         nodeMap.clear();
         // TODO: getRoots needs to be changed - the user might have specified specific roots
         Set<N> roots = provider.getRoots();
         OWLObjectTreeRootNode<N> rootNode = new OWLObjectTreeRootNode<N>(this, roots);
         ((DefaultTreeModel) getModel()).setRoot(rootNode);
+        setSelectedOWLObject(currentSelection);
     }
 
 


### PR DESCRIPTION
moved the OWLOntologyChangeListener from
InferredOWLClassHierarchyProvider to OWLReasonerManagerImpl and issuing
fireReclassified() in case of logical axiom changes plus import changes
(which were ignored before). This way all inferences in the UI should be
updated, not only the inferred class hierarchy.  
Not sure the code was/is safe to guarantee that the reasoner processes
changes before fireReclassified() because OWLManager processes listeners
in undefined order. I do not think calling this method within
SwingUtilities.infokeLater() makes it safe.