### PR TITLE
Fix Windows plugin update

### DIFF
--- a/org.protege.editor.core.application/src/main/java/org/protege/editor/core/update/PluginInstaller.java
+++ b/org.protege.editor.core.application/src/main/java/org/protege/editor/core/update/PluginInstaller.java
@@ -121,12 +121,12 @@ public class PluginInstaller {
     
     private File downloadPlugin(PluginInfo info) throws IOException {
         URL downloadURL = info.getDownloadURL();
-        final String[] path = downloadURL.getFile().split("/");
-        String downloadFileName = path[path.length-1];
-
-        String tmpPath = System.getProperty("java.io.tmpdir");
-        File tempPluginFile = new File(tmpPath, downloadFileName);
+        File tempPluginFile = File.createTempFile(info.getId(), ".jar");
         tempPluginFile.deleteOnExit();
+
+        logger.debug("Download URL: " + downloadURL.toString());
+        logger.debug("Temp file: " + tempPluginFile.getAbsolutePath());
+
         URLConnection conn = downloadURL.openConnection();
         BufferedInputStream bis = new BufferedInputStream(conn.getInputStream());
         BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(tempPluginFile));

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <dependency>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>org.apache.felix.main</artifactId>
-				<version>4.2.1</version>
+				<version>4.4.1</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
Patches from #97 and #98 to allow FaCT++ plugin work on Windows. Should also fix #107, and make plugin downloads more robust in general.