### PR TITLE
a few small changes for interaction with the reasoner

### DIFF
--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/inference/DisplayedInferencePreferences.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/inference/DisplayedInferencePreferences.java
@@ -116,9 +116,10 @@ public class DisplayedInferencePreferences {
         if (isShowInferences() && isEnabled(task)) {
             startClock(task);
             try {
-                implementation.run();
-            }
-            finally {
+                implementation.run();                
+            } catch (UnsupportedOperationException ignore) {
+            	
+            } finally {
             	stopClock(task);
             }
         }

--- a/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/inference/OWLReasonerManagerImpl.java
+++ b/org.protege.editor.owl/src/main/java/org/protege/editor/owl/model/inference/OWLReasonerManagerImpl.java
@@ -67,8 +67,11 @@ public class OWLReasonerManagerImpl implements OWLReasonerManager {
        	public void ontologiesChanged(List<? extends OWLOntologyChange> changes) throws OWLException {
        		OWLReasoner reasoner = getCurrentReasoner();       		
        		if (reasoner instanceof NoOpReasoner || reasoner.getBufferingMode() != BufferingMode.NON_BUFFERING)
-   				return;       		
+   				return;
+       		OWLOntology activeOntology = owlModelManager.getActiveOntology();
+       		Set<OWLOntology> importClosure = null;
        		boolean needsRefresh = false;
+       		
 			for (OWLOntologyChange change : changes) {
 				if (change instanceof AnnotationChange)
 					continue;
@@ -76,6 +79,15 @@ public class OWLReasonerManagerImpl implements OWLReasonerManager {
 					continue;
 				if (change instanceof OWLAxiomChange && !change.getAxiom().isLogicalAxiom())
 					continue;
+				OWLOntology changedOntology = change.getOntology();
+				if (!changedOntology.equals(activeOntology)) {
+					if (importClosure == null) {
+						importClosure = activeOntology.getImportsClosure();
+					}	
+					if (!importClosure.contains(changedOntology)) {
+						continue;
+					}	
+				}
 				// otherwise
 				needsRefresh = true;
 				break;


### PR DESCRIPTION
I made a small change which catches and ignores the UnsupportedOperationException when executing reasoning task. This way, owl reasoners can throw exception for reasoning tasks that they do not support and Protege will not misbehave (it should act, in principle, the same as if the reasoning task is not enabled).  

The second change is a bit more clever way for a reasoner in non-buffering mode to understand when changes in ontology may require reclassification. Essentially, only logical or import changes to ontologies in the import closure should be considered.