### PR TITLE
Adjust run scripts to find and cd to thier location before invoking J…

### DIFF
--- a/protege-desktop/src/main/env/linux/run.sh
+++ b/protege-desktop/src/main/env/linux/run.sh
@@ -1,6 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cd `dirname $0`
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+cd "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 jre/bin/java -Xmx${conf.mem.xmx} -Xms${conf.mem.xms} \
      -DentityExpansionLimit=100000000 \

--- a/protege-desktop/src/main/env/platform-independent/run.bat
+++ b/protege-desktop/src/main/env/platform-independent/run.bat
@@ -1,1 +1,3 @@
+setlocal
+cd /d %~dp0
 java -Xmx${conf.mem.xmx} -Xms${conf.mem.xms} ${conf.extra.args} -DentityExpansionLimit=100000000 -Dlogback.configurationFile=conf/logback.xml -Dfile.encoding=utf-8 -Dorg.protege.plugin.dir=plugins -classpath bundles/guava.jar;bundles/jansi.jar;bundles/logback-classic.jar;bundles/logback-core.jar;bundles/slf4j-api.jar;bin/org.apache.felix.main.jar;bin/protege-launcher.jar org.protege.osgi.framework.Launcher %1

--- a/protege-desktop/src/main/env/platform-independent/run.sh
+++ b/protege-desktop/src/main/env/platform-independent/run.sh
@@ -1,6 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cd `dirname $0`
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+cd "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 java -Xmx${conf.mem.xmx} -Xms${conf.mem.xms} \
      -Dlogback.configurationFile=conf/logback.xml \

--- a/protege-desktop/src/main/env/win/run.bat
+++ b/protege-desktop/src/main/env/win/run.bat
@@ -1,1 +1,3 @@
+setlocal
+cd /d %~dp0
 jre\bin\java -Xmx${conf.mem.xmx} -Xms${conf.mem.xms} ${conf.extra.args} -DentityExpansionLimit=100000000 -Dlogback.configurationFile=conf/logback.xml -Dfile.encoding=utf-8 -Dorg.protege.plugin.dir=plugins -classpath bundles/guava.jar;bundles/jansi.jar;bundles/logback-classic.jar;bundles/logback-core.jar;bundles/slf4j-api.jar;bin/org.apache.felix.main.jar;bin/protege-launcher.jar org.protege.osgi.framework.Launcher %1


### PR DESCRIPTION
…ava.

The previous scripts didn't work well with Linux symlinks or Windows calls.
I think the same Linux change should work for the Mac script but I don't
have one to test it.