### PR TITLE
Enable ability to disable drag/drop

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/transfer/OWLObjectTreeDragGestureListener.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/transfer/OWLObjectTreeDragGestureListener.java
@@ -33,6 +33,10 @@ public class OWLObjectTreeDragGestureListener extends OWLObjectDragGestureListen
     protected List<OWLObject> getSelectedObjects() {
         return tree.getSelectedOWLObjects();
     }
+    
+    protected boolean canPerformDrag() {
+    	return tree.getDragEnabled();
+    }
 
 
     protected JComponent getRendererComponent() {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/cls/ToldOWLClassHierarchyViewComponent.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/cls/ToldOWLClassHierarchyViewComponent.java
@@ -68,6 +68,8 @@ public class ToldOWLClassHierarchyViewComponent extends AbstractOWLClassHierarch
 
         addAction(new DeleteClassAction(getOWLEditorKit(),
                 () -> new HashSet<>(getTree().getSelectedOWLObjects())), "B", "A");
+        
+        getTree().setDragEnabled(true);
 
         getTree().setDragAndDropHandler(new OWLTreeDragAndDropHandler<OWLClass>() {
             public boolean canDrop(Object child, Object parent) {


### PR DESCRIPTION
Adds a method to OWObjectTreeDragGestureListener to call underlying tree's method to see
if drag is enabled.

@rsgoncalves the default is false so I added a call to `setDragEnabled` in the existing class, `ToldOWLClassHierarchyViewComponent`, there may be others