### PR TITLE
Add jsr305.jar to bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
 		<slf4j.version>1.7.12</slf4j.version>
 		<logback.version>1.1.3</logback.version>
 		<lib.location>target/lib</lib.location>
-		<jsr305.version>3.0.1</jsr305.version>
 	</properties>
 	
 	<dependencyManagement>
@@ -171,7 +170,7 @@
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>
-				<version>${jsr305.version}</version>
+				<version>3.0.1</version>
 			</dependency>
 
 			<dependency>

--- a/protege-common/pom.xml
+++ b/protege-common/pom.xml
@@ -44,8 +44,7 @@
 						<Bundle-ClassPath>.</Bundle-ClassPath>
 						<Bundle-SymbolicName>org.protege.common</Bundle-SymbolicName>
 						<Export-Package>
-							org.protege.common.*;version=${project.version},
-							javax.annotation.*;verions=${jsr305.version}
+							org.protege.common.*;version=${project.version}
 						</Export-Package>
 						<Import-Package>
 							!com.ibm.*, 

--- a/protege-desktop/src/main/assembly/dependency-sets.xml
+++ b/protege-desktop/src/main/assembly/dependency-sets.xml
@@ -24,6 +24,7 @@
                 <include>edu.stanford.protege:protege-editor-owl:jar</include>
                 <include>ch.qos.logback:logback-core:jar</include>
                 <include>ch.qos.logback:logback-classic:jar</include>
+                <include>com.google.code.findbugs:jsr305:jar</include>
                 <include>com.google.guava:guava:jar</include>
                 <include>org.slf4j:slf4j-api:jar</include>
                 <include>org.slf4j:log4j-over-slf4j:jar</include>


### PR DESCRIPTION
instead of exporting a (non-existing) package javax.annotation.*
in protege-common