### PR TITLE
Improve fix for #574

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OntologyReloader.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OntologyReloader.java
@@ -73,21 +73,15 @@ public class OntologyReloader {
     }
 
     private List<OWLOntologyChange> reloadOntologyAndGetPatch() throws OWLOntologyCreationException {
-        ListenableFuture<List<OWLOntologyChange>> future = executorService.submit(this::performReloadAndGetPatch);
-        Futures.addCallback(future, new FutureCallback<List<OWLOntologyChange>>() {
-            @Override
-            public void onSuccess(List<OWLOntologyChange> result) {
-                dlg.setVisible(false);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                dlg.setVisible(false);
-            }
-        });
-        if (!future.isDone()) {
-            dlg.setVisible(true);
-        }
+		ListenableFuture<List<OWLOntologyChange>> future = executorService
+				.submit(() -> {
+					dlg.setVisible(true);
+					try {
+						return performReloadAndGetPatch();
+					} finally {
+						dlg.setVisible(false);
+					}
+				});
         try {
             return future.get();
         } catch (InterruptedException e) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/io/OntologySaver.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/io/OntologySaver.java
@@ -48,20 +48,14 @@ public class OntologySaver {
      * @throws OWLOntologyStorageException if there was a problem saving an ontology.
      */
     public void saveOntologies() throws OWLOntologyStorageException {
-        ListenableFuture<Void> future = executorService.submit(this::saveOntologyInternal);
-        Futures.addCallback(future, new FutureCallback<Void>() {
-            @Override
-            public void onSuccess(Void result) {
-                dlg.setVisible(false);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                dlg.setVisible(false);
-            }
-        });
-        // Block here
-        dlg.setVisible(true);
+		ListenableFuture<Void> future = executorService.submit(() -> {
+			dlg.setVisible(true);
+			try {
+				return saveOntologyInternal();
+			} finally {
+				dlg.setVisible(false);
+			}
+		});
         try {
             future.get();
         } catch (InterruptedException e) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/ontology/imports/AddImportsStrategy.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/ontology/imports/AddImportsStrategy.java
@@ -61,26 +61,20 @@ public class AddImportsStrategy {
     }
 
     private void addImportsInOtherThread() {
-        ListenableFuture<List<OWLOntologyChange>> future = service.submit(this::loadImportsInternal);
-        Futures.addCallback(future, new FutureCallback<List<OWLOntologyChange>>() {
-            @Override
-            public void onSuccess(List<OWLOntologyChange> result) {
-                SwingUtilities.invokeLater(() -> {
-                    logger.info("Adding imports statements");
-                    editorKit.getModelManager().applyChanges(result);
-                    logger.info("Finished adding imports");
-                });
-                dlg.setVisible(false);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                dlg.setVisible(false);
-            }
-        });
-        if (!future.isDone()) {
-            dlg.setVisible(true);
-        }
+		service.submit(() -> {
+			dlg.setVisible(true);
+			try {
+				List<OWLOntologyChange> result = loadImportsInternal();
+				SwingUtilities.invokeLater(() -> {
+					logger.info("Adding imports statements");
+					editorKit.getModelManager().applyChanges(result);
+					logger.info("Finished adding imports");
+				});
+				return result;
+			} finally {
+				dlg.setVisible(false);
+			}
+		});        
     }
 
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/util/ProgressDialog.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/util/ProgressDialog.java
@@ -33,12 +33,11 @@ public class ProgressDialog {
      * event dispatch thread when it is shown.
      * The dialog will be packed and positioned before it is made visible.
      * Note that this method may be called from a thread other than the event dispatch thread.  The implementation
-     * will check to see whether the calling thread is the event dispatch thread or not and, if necessary, will
-     * use SwingUtilities.invoke later.
+     * will use SwingUtilities.invoke later.
      * @param visible true if the dialog should be made visible, or false if the dialog should be hidden.
      */
     public void setVisible(boolean visible) {
-        Runnable r = () -> {
+    	SwingUtilities.invokeLater(() -> {
             if (visible) {
                 dlg.pack();
                 Dimension prefSize = dlg.getPreferredSize();
@@ -49,17 +48,9 @@ public class ProgressDialog {
                         (screenSize.height - prefSize.height) / 2);
                 dlg.setVisible(true);
             } else {
-                dlg.setVisible(false);
-                dlg.dispose();
+            	dlg.dispose(); // dlg.setVisible(false) has problems with openjdk; see https://bugs.openjdk.java.net/browse/JDK-5109571
             }
-        };
-
-        if(SwingUtilities.isEventDispatchThread()) {
-            r.run();
-        }
-        else {
-            SwingUtilities.invokeLater(r);
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
- The problem with stuck progress dialog was likely caused by
  the openjdk bug https://bugs.openjdk.java.net/browse/JDK-5109571
  using JDialog.dispose() instead of JDialog.setVisible(false)
  seems to avoid this bug

- ProgressDialog: dlg.setVisible(false) is no longer necessary since
dlg.displose() takes care about hiding the dialog

- ProgressDialog.setVisible() always uses SwingUtilities.invokeLater()
to ensure that if setVisible(false) is called after setVisible(true)
then the dialog is shown before it is disposed
(this may be not true if one is called on EDT and the other is not)

- ensure that ProgressDialog.setVisible(false) is called after
  ProgressDialog.setVisible(true); this was not the case, e.g.,
  in OntologySaver if saving finishes before 
  ProgressDialog.setVisible(true) is called
  instead of using executor callbacks, use try { } finally { };