### PR TITLE
Fix delayed progress dialog due to the fix for #574

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OntologyReloader.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OntologyReloader.java
@@ -3,17 +3,13 @@ package org.protege.editor.owl.model;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.*;
 import org.protege.editor.core.log.LogBanner;
-import org.protege.editor.owl.model.io.IOListener;
 import org.protege.editor.owl.ui.util.ProgressDialog;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
-import org.semanticweb.owlapi.model.parameters.OntologyCopy;
 import org.semanticweb.owlapi.util.PriorityCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.*;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -74,14 +70,14 @@ public class OntologyReloader {
 
     private List<OWLOntologyChange> reloadOntologyAndGetPatch() throws OWLOntologyCreationException {
 		ListenableFuture<List<OWLOntologyChange>> future = executorService
-				.submit(() -> {
-					dlg.setVisible(true);
+				.submit(() -> {					
 					try {
 						return performReloadAndGetPatch();
 					} finally {
 						dlg.setVisible(false);
 					}
 				});
+		dlg.setVisible(true);
         try {
             return future.get();
         } catch (InterruptedException e) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/io/OntologyLoader.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/io/OntologyLoader.java
@@ -53,16 +53,16 @@ public class OntologyLoader {
         return loadOntologyInOtherThread(documentUri);
     }
 
-    private Optional<OWLOntology> loadOntologyInOtherThread(URI uri) throws OWLOntologyCreationException {
-		ListenableFuture<Optional<OWLOntology>> result = ontologyLoadingService
-				.submit(() -> {
-					dlg.setVisible(true);
-					try {
+    private Optional<OWLOntology> loadOntologyInOtherThread(URI uri) throws OWLOntologyCreationException {    	
+    	ListenableFuture<Optional<OWLOntology>> result = ontologyLoadingService
+				.submit(() -> {					
+					try {						
 						return loadOntologyInternal(uri);
 					} finally {
 						dlg.setVisible(false);
 					}					
 				});
+    	dlg.setVisible(true);
         try {
             return result.get();
         } catch (InterruptedException e) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/io/OntologySaver.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/io/OntologySaver.java
@@ -2,7 +2,6 @@ package org.protege.editor.owl.model.io;
 
 import com.google.common.util.concurrent.*;
 import org.apache.commons.io.FileUtils;
-import org.protege.editor.core.log.LogBanner;
 import org.protege.editor.owl.ui.util.ProgressDialog;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLDocumentFormat;
@@ -48,14 +47,14 @@ public class OntologySaver {
      * @throws OWLOntologyStorageException if there was a problem saving an ontology.
      */
     public void saveOntologies() throws OWLOntologyStorageException {
-		ListenableFuture<Void> future = executorService.submit(() -> {
-			dlg.setVisible(true);
+		ListenableFuture<Void> future = executorService.submit(() -> {			
 			try {
 				return saveOntologyInternal();
 			} finally {
 				dlg.setVisible(false);
 			}
 		});
+		dlg.setVisible(true);
         try {
             future.get();
         } catch (InterruptedException e) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/ontology/imports/AddImportsStrategy.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/ontology/imports/AddImportsStrategy.java
@@ -4,10 +4,8 @@ import com.google.common.util.concurrent.*;
 import org.protege.editor.core.log.LogBanner;
 import org.protege.editor.core.ui.util.UIUtil;
 import org.protege.editor.owl.OWLEditorKit;
-import org.protege.editor.owl.model.event.EventType;
 import org.protege.editor.owl.model.io.*;
 import org.protege.editor.owl.model.library.OntologyCatalogManager;
-import org.protege.editor.owl.ui.ontology.imports.missing.MissingImportHandlerUI;
 import org.protege.editor.owl.ui.ontology.imports.wizard.ImportInfo;
 import org.protege.editor.owl.ui.util.ProgressDialog;
 import org.protege.xmlcatalog.CatalogUtilities;
@@ -17,7 +15,6 @@ import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.io.IRIDocumentSource;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.OntologyCopy;
-import org.semanticweb.owlapi.util.PriorityCollection;
 import org.semanticweb.owlapi.util.SimpleIRIMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,8 +58,7 @@ public class AddImportsStrategy {
     }
 
     private void addImportsInOtherThread() {
-		service.submit(() -> {
-			dlg.setVisible(true);
+		service.submit(() -> {			
 			try {
 				List<OWLOntologyChange> result = loadImportsInternal();
 				SwingUtilities.invokeLater(() -> {
@@ -74,7 +70,8 @@ public class AddImportsStrategy {
 			} finally {
 				dlg.setVisible(false);
 			}
-		});        
+		});
+		dlg.setVisible(true);
     }
 
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/util/ProgressDialog.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/util/ProgressDialog.java
@@ -33,11 +33,12 @@ public class ProgressDialog {
      * event dispatch thread when it is shown.
      * The dialog will be packed and positioned before it is made visible.
      * Note that this method may be called from a thread other than the event dispatch thread.  The implementation
-     * will use SwingUtilities.invoke later.
+     * will check to see whether the calling thread is the event dispatch thread or not and, if necessary, will
+     * use SwingUtilities.invoke later.
      * @param visible true if the dialog should be made visible, or false if the dialog should be hidden.
      */
     public void setVisible(boolean visible) {
-    	SwingUtilities.invokeLater(() -> {
+        Runnable r = () -> {
             if (visible) {
                 dlg.pack();
                 Dimension prefSize = dlg.getPreferredSize();
@@ -50,7 +51,14 @@ public class ProgressDialog {
             } else {
             	dlg.dispose(); // dlg.setVisible(false) has problems with openjdk; see https://bugs.openjdk.java.net/browse/JDK-5109571
             }
-        });
+        };
+
+        if(visible && SwingUtilities.isEventDispatchThread()) {
+            r.run();
+        }
+        else {
+            SwingUtilities.invokeLater(r);
+        }
     }
 
     /**


### PR DESCRIPTION
Because loading / saving / reloading blocks the event dispatch thread,
SwingUtilities.invokeLater that were used to show and hide
the progress dialog, were executed *after* these operations finish.

Now revert the changes to execute dlg.setVisible(true) immediately 
after the main task has been submitted. Since it is executed on
event dispatch thread, dialog will be shown immediately.
The dialog will not be hidden before it is shown since 
dlg.setVisible(false) *always* uses SwingUtilities.invokeLater.