### PR TITLE
Add explanation preferences menu and extension point

### DIFF
--- a/protege-editor-core/schema/explanationpreferencespanel.exsd
+++ b/protege-editor-core/schema/explanationpreferencespanel.exsd
@@ -1,0 +1,115 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.protege.editor.core.application" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.protege.editor.core.application" id="explanationpreferencespanel" name="explanationpreferencespanel"/>
+      </appInfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="label"/>
+            <element ref="class"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="label">
+      <complexType>
+         <attribute name="value" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="class">
+      <complexType>
+         <attribute name="value" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn="org.protege.editor.core.ui.preferences.PreferencesPanel:"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiInfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/explanationpreferences/ExplanationPreferencesPanel.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/explanationpreferences/ExplanationPreferencesPanel.java
@@ -1,0 +1,130 @@
+package org.protege.editor.core.ui.explanationpreferences;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.border.EmptyBorder;
+
+import org.protege.editor.core.Disposable;
+import org.protege.editor.core.editorkit.EditorKit;
+import org.protege.editor.core.prefs.Preferences;
+import org.protege.editor.core.prefs.PreferencesManager;
+import org.protege.editor.core.ui.preferences.PreferencesDialogPanel;
+import org.protege.editor.core.ui.preferences.PreferencesPanel;
+import org.protege.editor.core.ui.preferences.PreferencesPanelPlugin;
+import org.protege.editor.core.ui.preferences.PreferencesPanelPluginLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExplanationPreferencesPanel extends PreferencesPanel implements Disposable {
+
+    private final Map<String, PreferencesPanel> map = new HashMap<>();
+
+    private final Map<String, JComponent> componentMap = new HashMap<>();
+
+    private final JTabbedPane tabbedPane = new JTabbedPane();
+
+    private final Logger logger = LoggerFactory.getLogger(ExplanationPreferencesPanel.class);
+
+    private static final String EXPL_PREFS_HISTORY_PANEL_KEY = "expl.prefs.history.panel";
+
+    @Override
+    public void dispose() throws Exception {
+        final Preferences prefs = PreferencesManager.getInstance().getApplicationPreferences(ExplanationPreferencesPanel.class);
+        prefs.putString(EXPL_PREFS_HISTORY_PANEL_KEY, getSelectedPanel());
+        for (PreferencesPanel panel : new ArrayList<>(map.values())) {
+            try {
+                panel.dispose();
+            }
+            catch (Throwable e) {
+                logger.warn("An error occurred whilst disposing of the explanation preferences panel plugin '{}': {}", panel.getLabel(), e);
+            }
+        }
+        map.clear();
+    }
+
+    protected String getSelectedPanel() {
+        Component c = tabbedPane.getSelectedComponent();
+        if (c instanceof JScrollPane){
+            c = ((JScrollPane)c).getViewport().getView();
+        }
+        for (String tabName : map.keySet()){
+            if (c.equals(map.get(tabName))){
+                return tabName;
+            }
+        }
+        return null;
+    }
+
+    public void updatePanelSelection(String selectedPanel) {
+    	if (selectedPanel == null){
+            final Preferences prefs = PreferencesManager.getInstance().getApplicationPreferences(ExplanationPreferencesPanel.class);
+            selectedPanel = prefs.getString(EXPL_PREFS_HISTORY_PANEL_KEY, null);
+        }
+        Component c = componentMap.get(selectedPanel);
+        if (c != null) {
+            tabbedPane.setSelectedComponent(c);
+        }
+    }
+
+    @Override
+    public void initialise() throws Exception {
+        setLayout(new BorderLayout());
+
+        ExplanationPreferencesPanelPluginLoader loader = new ExplanationPreferencesPanelPluginLoader(getEditorKit());
+        Set<PreferencesPanelPlugin> plugins = new TreeSet<>((o1, o2) -> {
+                String s1 = o1.getLabel();
+                String s2 = o2.getLabel();
+                return s1.compareTo(s2);
+        });
+        plugins.addAll(loader.getPlugins());
+
+        for (PreferencesPanelPlugin plugin : plugins) {
+            try {
+                PreferencesPanel panel = plugin.newInstance();
+                panel.initialise();
+                String label = plugin.getLabel();
+                final JScrollPane sp = new JScrollPane(panel);
+                sp.setBorder(new EmptyBorder(0, 0, 0, 0));
+                map.put(label, panel);
+                componentMap.put(label, sp);
+                tabbedPane.addTab(label, sp);
+            } catch (Throwable e) {
+                logger.warn("An error occurred whilst trying to instantiate the explanation preferences panel plugin '{}': {}", plugin.getLabel(), e);
+            }
+        }
+
+        add(tabbedPane);
+
+        updatePanelSelection(null);
+    }
+
+	@Override
+	public void applyChanges() {
+        for (PreferencesPanel panel : new ArrayList<>(map.values())) {
+            try {
+                panel.applyChanges();
+            }
+            catch (Throwable e) {
+                logger.warn("An error occurred whilst trying to save the preferences for the explanation preferences panel '{}': {}", panel.getLabel(), e);
+            }
+        }
+	}
+}

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/explanationpreferences/ExplanationPreferencesPanelPluginJPFImpl.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/explanationpreferences/ExplanationPreferencesPanelPluginJPFImpl.java
@@ -1,0 +1,36 @@
+package org.protege.editor.core.ui.explanationpreferences;
+
+import org.eclipse.core.runtime.IExtension;
+import org.protege.editor.core.editorkit.EditorKit;
+import org.protege.editor.core.plugin.AbstractProtegePlugin;
+import org.protege.editor.core.ui.preferences.PreferencesPanel;
+import org.protege.editor.core.ui.preferences.PreferencesPanelPlugin;
+
+public class ExplanationPreferencesPanelPluginJPFImpl extends AbstractProtegePlugin<PreferencesPanel>
+		implements PreferencesPanelPlugin {
+
+    public static final String ID = "explanationpreferencespanel";
+
+    public static final String LABEL_PARAM = "label";
+
+    private EditorKit editorKit;
+
+
+    public ExplanationPreferencesPanelPluginJPFImpl(IExtension extension, EditorKit editorKit) {
+        super(extension);
+        this.editorKit = editorKit;
+    }
+
+
+    public String getLabel() {
+        return getPluginProperty(LABEL_PARAM);
+    }
+
+    public PreferencesPanel newInstance() throws ClassNotFoundException, IllegalAccessException,
+                                                 InstantiationException {
+    	PreferencesPanel panel = super.newInstance();
+        panel.setup(getLabel(), editorKit);
+        return panel;
+    }
+    
+}

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/explanationpreferences/ExplanationPreferencesPanelPluginLoader.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/explanationpreferences/ExplanationPreferencesPanelPluginLoader.java
@@ -1,0 +1,31 @@
+package org.protege.editor.core.ui.explanationpreferences;
+
+import org.eclipse.core.runtime.IExtension;
+import org.protege.editor.core.editorkit.EditorKit;
+import org.protege.editor.core.plugin.AbstractApplicationPluginLoader;
+import org.protege.editor.core.plugin.PluginExtensionMatcher;
+import org.protege.editor.core.plugin.PluginParameterExtensionMatcher;
+import org.protege.editor.core.ui.preferences.PreferencesPanelPlugin;
+
+public class ExplanationPreferencesPanelPluginLoader
+		extends AbstractApplicationPluginLoader<PreferencesPanelPlugin> {
+
+    private EditorKit editorKit;
+
+
+    public ExplanationPreferencesPanelPluginLoader(EditorKit editorKit) {
+        super(ExplanationPreferencesPanelPluginJPFImpl.ID);
+        this.editorKit = editorKit;
+    }
+
+
+    protected PluginExtensionMatcher getExtensionMatcher() {
+        return new PluginParameterExtensionMatcher();
+    }
+
+
+    protected PreferencesPanelPlugin createInstance(IExtension extension) {
+        return new ExplanationPreferencesPanelPluginJPFImpl(extension, editorKit);
+    }
+    
+}

--- a/protege-editor-core/src/main/resources/plugin.xml
+++ b/protege-editor-core/src/main/resources/plugin.xml
@@ -17,6 +17,9 @@
    <extension-point id="preferencespanel" 
                     name="preferencespanel"
                     schema="schema/preferencespanel.exsd"/>
+   <extension-point id="explanationpreferencespanel"
+                    name="explanationpreferencespanel"
+                    schema="schema/explanationpreferencespanel.exsd"/>
    <extension-point id="EditorKitHook"
                      name="EditorKit Hook"
                      schema="schema/EditorKitHook.exsd"/>
@@ -258,6 +261,12 @@
         <url value="http://protege.stanford.edu/about.php#citing"/>
         <path value="org.protege.editor.core.application.menu.HelpMenu/SlotH-A"/>
         <editorKitId value="any"/>
+    </extension>
+
+    <extension id="ui.preferences.explanation"
+               point="org.protege.editor.core.application.preferencespanel">
+        <label value="Explanations"/>
+        <class value="org.protege.editor.core.ui.explanationpreferences.ExplanationPreferencesPanel"/>
     </extension>
 
     <!-- Autoupdate preferences -->

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationPreferencesGeneralPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationPreferencesGeneralPanel.java
@@ -1,0 +1,44 @@
+package org.protege.editor.owl.ui.explanation;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.util.Collection;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+
+import org.protege.editor.core.ui.preferences.PreferencesLayoutPanel;
+import org.protege.editor.owl.ui.preferences.OWLPreferencesPanel;
+
+public class ExplanationPreferencesGeneralPanel extends OWLPreferencesPanel {
+
+	private static final long serialVersionUID = -3354987384223578780L;
+
+	@Override
+    public void initialise() throws Exception {
+        setLayout(new BorderLayout());
+        PreferencesLayoutPanel panel = new PreferencesLayoutPanel();
+        add(panel, BorderLayout.NORTH);
+
+        panel.addGroup("Installed explanation services");
+        DefaultListModel<String> pluginModel = new DefaultListModel<>();
+        ExplanationManager manager = new ExplanationManager(getOWLEditorKit());
+        Collection<ExplanationService> services = manager.getExplainers();
+        for (ExplanationService service : services)
+            pluginModel.addElement(service.getName());
+        JList<String> pluginList = new JList<>(pluginModel);
+        pluginList.setToolTipText("Plugins that provide explanation facilities");
+        JScrollPane pluginInfoScrollPane = new JScrollPane(pluginList);
+        pluginInfoScrollPane.setPreferredSize(new Dimension(300, 100));
+        panel.addGroupComponent(pluginInfoScrollPane);
+    }
+
+    @Override
+    public void dispose() throws Exception {
+    }
+
+    @Override
+    public void applyChanges() {
+    }
+}

--- a/protege-editor-owl/src/main/resources/plugin.xml
+++ b/protege-editor-owl/src/main/resources/plugin.xml
@@ -1495,6 +1495,12 @@
         <class value="org.protege.editor.owl.ui.annotation.EntityCreationMetadataPreferencesPanel"/>
     </extension>
 
+    <extension id="ui.preferences.explanation.general"
+               point="org.protege.editor.core.application.explanationpreferencespanel">
+        <label value="General"/>
+        <class value="org.protege.editor.owl.ui.explanation.ExplanationPreferencesGeneralPanel"/>
+    </extension>
+
     <!-- Move axioms kits -->
 
     <extension id="MoveAxiomsByReference"


### PR DESCRIPTION
This patch adds a new explanation preferences menu tab so that explanation plugins can put their preferences under it. This is managed by providing an extension point explanationpreferences.
By default, the explanation preferences menu has just one tab "General" which lists all installed explanation services.