### PR TITLE
Improve management of embedded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,9 @@
 							<extensions>true</extensions>
 							<configuration>
 								<manifestLocation>META-INF</manifestLocation>
+								<instructions>
+								<Bundle-ClassPath>.,target/dependency</Bundle-ClassPath>
+								</instructions>
 							</configuration>
 						</plugin>
 						<!-- Copy all Maven dependencies so that it is possible to run Protege 
@@ -474,22 +477,17 @@
 							<version>2.8</version>
 							<executions>
 								<execution>
-									<id>copy-dependencies</id>
-									<phase>process-sources</phase>
+									<id>copy-provided-dependencies</id>
+									<phase>package</phase>
 									<goals>
-										<goal>copy-dependencies</goal>
+										<goal>unpack-dependencies</goal>
 									</goals>
-									<configuration>
-										<outputDirectory>${lib.location}</outputDirectory>
-										<excludeScope>provided</excludeScope>
-										<includeScope>compile</includeScope>
-										<includeScope>runtime</includeScope>										
-										<overWriteReleases>false</overWriteReleases>
-										<overWriteSnapshots>false</overWriteSnapshots>
-										<overWriteIfNewer>true</overWriteIfNewer>
-									</configuration>
 								</execution>
 							</executions>
+							<configuration>
+								<includeScope>provided</includeScope>
+								<outputDirectory>${project.build.directory}/dependency</outputDirectory>
+							</configuration>
 						</plugin>
 						<!-- Copy plugin.xml where PDE in Eclipse can find it (PDE + m2e + 
 							OSGi Framework launcher). -->

--- a/protege-common/pom.xml
+++ b/protege-common/pom.xml
@@ -22,7 +22,6 @@
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>protege-launcher</artifactId>
 			<version>${project.parent.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
         <dependency>

--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -22,24 +22,26 @@
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>protege-launcher</artifactId>
 			<version>${project.parent.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.googlecode.mdock</groupId>
 			<artifactId>mdock</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.jgoodies</groupId>
 			<artifactId>jgoodies-looks</artifactId>
 			<version>2.5.3</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.jgoodies</groupId>
 			<artifactId>jgoodies-common</artifactId>
 			<version>1.6.0</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -72,7 +74,7 @@
 					<instructions>
 						<Bundle-Activator>org.protege.editor.core.ProtegeApplication</Bundle-Activator>						
 						<Bundle-SymbolicName>org.protege.editor.core.application;singleton:=true</Bundle-SymbolicName>
-						<Embed-Dependency>*;scope=!provided;scope=compile|runtime;inline=false</Embed-Dependency>
+						<Embed-Dependency>*;scope=provided;inline=true</Embed-Dependency>
 						<Export-Package>
 							org.protege.editor.core.*,
 						</Export-Package>

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/list/MListEditButton.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/list/MListEditButton.java
@@ -2,6 +2,8 @@ package org.protege.editor.core.ui.list;
 
 import java.awt.*;
 import java.awt.event.ActionListener;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
 
 
 /**
@@ -12,20 +14,24 @@ import java.awt.event.ActionListener;
  */
 public class MListEditButton extends MListButton {
 
+	private final Ellipse2D border_ = new Ellipse2D.Float();
+	
     public MListEditButton(ActionListener actionListener) {
         super("Edit", new Color(20, 80, 210), actionListener);
     }
 
-
-    public void paintButtonContent(Graphics2D g) {
+    @Override
+	public void paintButtonContent(Graphics2D g) {
         Rectangle bounds = getBounds();
         int x = bounds.x;
         int y = bounds.y;
         int size = bounds.width;
         int quarterSize = (Math.round(bounds.width / 4.0f) / 2) * 2;
-        g.fillOval(x + size / 2 - quarterSize, y + size / 2 - quarterSize, 2 * quarterSize, 2 * quarterSize);
-        g.setColor(getBackground());
-        g.fillOval(x + size / 2 - quarterSize / 2, y + size / 2 - quarterSize / 2, quarterSize, quarterSize);
+        border_.setFrame(x + size / 2 - quarterSize, y + size / 2 - quarterSize, 2 * quarterSize, 2 * quarterSize);
+        Area area = new Area(border_);
+        border_.setFrame(x + size / 2 - quarterSize / 2, y + size / 2 - quarterSize / 2, quarterSize, quarterSize);
+        area.subtract(new Area(border_));
+        g.fill(area);
     }
 
     @Override

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -21,26 +21,24 @@
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>protege-launcher</artifactId>
 			<version>${project.parent.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>protege-common</artifactId>
             <version>${project.parent.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>protege-editor-core</artifactId>
             <version>${project.parent.version}</version>
-            <scope>provided</scope>
         </dependency>
 
 		<dependency>
 			<groupId>edu.stanford.protege</groupId>
 			<artifactId>org.protege.xmlcatalog</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -79,7 +77,7 @@
                     <instructions>
                         <Bundle-Activator>org.protege.editor.owl.ProtegeOWL</Bundle-Activator>
                         <Bundle-SymbolicName>org.protege.editor.owl;singleton:=true</Bundle-SymbolicName>
-                        <Embed-Dependency>*;scope=!provided;scope=compile|runtime;inline=false</Embed-Dependency>
+                        <Embed-Dependency>*;scope=provided;inline=true</Embed-Dependency>
                         <Export-Package>
                             org.protege.editor.owl.*;version=${project.version},
                             org.protege.owlapi.inference.*;version=${project.version}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/AbstractOWLFrame.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/AbstractOWLFrame.java
@@ -49,14 +49,19 @@ public abstract class AbstractOWLFrame<R extends Object> implements OWLFrame<R> 
     }
 
 
+    private void disposeSections() {
+    	sections.forEach(OWLFrameSection::dispose);
+    }
+    
     protected void clearSections() {
+    	disposeSections();
         sections.clear();
         fireContentChanged();
     }
 
 
     public void dispose() {
-        sections.forEach(OWLFrameSection::dispose);
+    	disposeSections();
     }
 
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
@@ -797,12 +797,38 @@ public class OWLCellRenderer implements TableCellRenderer, TreeCellRenderer, Lis
                     // Paint red because of inconsistency
                     doc.setCharacterAttributes(tokenStartIndex, tokenLength, inconsistentClassStyle, true);
                 }
-                else if (isOntologyURI(curToken)){
-                    fadeOntologyURI(doc, tokenStartIndex, tokenLength, enclosedByBracket);
-                }
-                else if (curToken.equals("(")){
-                    parenthesisRendered = true;
-                }
+				else
+					switch (curToken) {
+					case " ":
+						break;
+					case "(":
+						parenthesisRendered = true;
+						break;
+					case ")":
+						break;
+					case "[":
+						break;
+					case "]":
+						break;
+					case "{":
+						break;
+					case "}":
+						break;
+					case ",":
+						break;	
+					case "\n":
+						break;					
+					case "\t":
+						break;
+					case "'":
+						break;					
+					default:
+						// expensive test!
+						if (isOntologyURI(curToken)) {
+							fadeOntologyURI(doc, tokenStartIndex, tokenLength,
+									enclosedByBracket);
+						}
+					}
             }
         }
     }


### PR DESCRIPTION
Embedded dependencies are now specified with the "provided" scope.
They are also unpacked in the resulting jar instead of being embedded
(jar in jar).

For example, all classes of mdock are available dirctly from
protege-editor-core, and if someone uses protege-editor-core in maven,
the dependency on madock will not be pulled from maven central.

This should help eliminating duplicate classes on the classpath.

Address #611 since now protege-editor-core is provided as a normal
dependency of protege-editor-owl. Previously it was with the scope
"provided" which means that it was excluded from transitive
dependencies.

As before, the scope "provided" scope is used to distinguish embedded
dependencies from the remaining dependencies when creating bundles