### PR TITLE
Xml catalog editor improvements

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/library/NextCatalogManager.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/library/NextCatalogManager.java
@@ -1,6 +1,7 @@
 package org.protege.editor.owl.model.library;
 
 import org.protege.editor.owl.ui.library.NewEntryPanel;
+import org.protege.editor.owl.ui.library.plugins.NextCatalogPanel;
 import org.protege.xmlcatalog.XMLCatalog;
 import org.protege.xmlcatalog.entry.Entry;
 import org.protege.xmlcatalog.entry.NextCatalogEntry;
@@ -12,12 +13,12 @@ public class NextCatalogManager extends CatalogEntryManager {
 
     
     public String getDescription() {
-        return "Import Ontology Library";
+        return "Import XML Catalog";
     }
 
     
     public String getDescription(Entry entry) {
-        return "<html><body><b>Import Repository " +
+        return "<html><body><b>"+getDescription()+" " +
                 ((NextCatalogEntry) entry).getCatalog() +
                 "</b></body></html>";
     }
@@ -34,7 +35,7 @@ public class NextCatalogManager extends CatalogEntryManager {
 
     
     public NewEntryPanel newEntryPanel(XMLCatalog catalog) {
-        return null;
+        return new NextCatalogPanel(catalog);
     }
 
     

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/library/RewriteUriEntryManager.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/library/RewriteUriEntryManager.java
@@ -1,0 +1,49 @@
+package org.protege.editor.owl.model.library;
+
+import org.protege.editor.owl.ui.library.NewEntryPanel;
+import org.protege.editor.owl.ui.library.plugins.RewriteUriEntryPanel;
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.Entry;
+import org.protege.xmlcatalog.entry.NextCatalogEntry;
+import org.protege.xmlcatalog.entry.RewriteUriEntry;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by vblagodarov on 03-08-17.
+ */
+public class RewriteUriEntryManager extends CatalogEntryManager {
+    @Override
+    public boolean isSuitable(Entry entry) {
+        return entry instanceof RewriteUriEntry;
+    }
+
+    @Override
+    public boolean update(Entry entry) throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean initializeCatalog(File folder, XMLCatalog catalog) throws IOException {
+        return false;
+    }
+
+    @Override
+    public NewEntryPanel newEntryPanel(XMLCatalog catalog) {
+        return new RewriteUriEntryPanel(catalog);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Rewrite uri entry";
+    }
+
+    @Override
+    public String getDescription(Entry entry) {
+        RewriteUriEntry rewriteEntry = (RewriteUriEntry) entry;
+        return "<html><body><b>Rewrite " + rewriteEntry.getUriStartString() + "</b><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+                + "<font color=\"gray\"> by: " + rewriteEntry.getRewritePrefix() + "</font><p> </p></body></html>";
+    }
+
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/AddEntryDialog.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/AddEntryDialog.java
@@ -30,7 +30,7 @@ public class AddEntryDialog extends JDialog {
         dialog.setVisible(true);
         Entry e = dialog.getEntry();
         if (e != null) {
-            catalog.addEntry(0, e);
+            catalog.addEntry(e);
             for (CatalogEntryManager entryManager : entryManagers) {
                 if (entryManager.isSuitable(e)) {
                     try {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/ChooseFileAction.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/ChooseFileAction.java
@@ -1,0 +1,37 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.xmlcatalog.CatalogUtilities;
+import org.protege.xmlcatalog.XmlBaseContext;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.net.URI;
+
+/**
+ * Created by vblagodarov on 09-08-17.
+ */
+public class ChooseFileAction extends AbstractAction {
+    private JComponent parent;
+    private XmlBaseContext original;
+    private JTextField physicalLocation;
+
+    public ChooseFileAction(JComponent parent, XmlBaseContext original, JTextField physicalLocation) {
+        this.parent = parent;
+        this.original = original;
+        this.physicalLocation = physicalLocation;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        JFileChooser fileChooser = new JFileChooser();
+        URI base = CatalogUtilities.resolveXmlBase(original);
+        File directory;
+        if (base != null && (directory = new File(base)).isDirectory()) {
+            fileChooser.setCurrentDirectory(directory);
+        }
+        int retValue = fileChooser.showOpenDialog(parent);
+        if (retValue == JFileChooser.APPROVE_OPTION) {
+            physicalLocation.setText(fileChooser.getSelectedFile().toURI().toString());
+        }
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/DeleteRedirectAction.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/DeleteRedirectAction.java
@@ -1,43 +1,27 @@
 package org.protege.editor.owl.ui.library;
 
+import org.protege.xmlcatalog.XMLCatalog;
 import org.protege.xmlcatalog.entry.Entry;
-import org.protege.xmlcatalog.entry.GroupEntry;
-import org.protege.xmlcatalog.entry.NextCatalogEntry;
-
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.TreePath;
 import java.awt.event.ActionEvent;
 
 public class DeleteRedirectAction extends AbstractAction {
-    private JTree tree;
-    private TreePath selectionPath;
+    private DefaultMutableTreeNode node;
+    private XMLCatalog catalog;
+    private OntologyLibraryPanel.JTreeRefresh refreshTree;
     
-    public DeleteRedirectAction(JTree tree, TreePath selectionPath) {
+    public DeleteRedirectAction(XMLCatalog catalog, DefaultMutableTreeNode nodeToDelete, OntologyLibraryPanel.JTreeRefresh action) {
         super("Delete Library Entry");
-        this.selectionPath = selectionPath;
-        this.tree = tree;
+        node = nodeToDelete;
+        this.catalog = catalog;
+        refreshTree = action;
     }
     
     public void actionPerformed(ActionEvent e) {
-        DefaultMutableTreeNode nodeToDelete = (DefaultMutableTreeNode) selectionPath.getLastPathComponent();
-        boolean deleteFromTree = false;
-        Entry toDelete = (Entry) nodeToDelete.getUserObject();
-        Object o = ((DefaultMutableTreeNode) selectionPath.getParentPath().getLastPathComponent()).getUserObject();
-        
-        if (o instanceof GroupEntry) {
-            GroupEntry group = (GroupEntry) o;
-            group.removeEntry(toDelete);
-            deleteFromTree = true;
-        }
-        else if (o instanceof NextCatalogEntry) {
-            NextCatalogEntry subCatalogEntry = (NextCatalogEntry) o;
-            throw new UnsupportedOperationException("Not implemented yet");
-        }
-        if (deleteFromTree)  {
-            ((DefaultTreeModel) tree.getModel()).removeNodeFromParent(nodeToDelete);
-            tree.repaint();
+        if(node.getUserObject() !=null){
+            catalog.removeEntry((Entry) node.getUserObject());
+            refreshTree.refreshView();
         }
     }
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/EditLibraryEntryAction.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/EditLibraryEntryAction.java
@@ -1,0 +1,79 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.Entry;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+
+/**
+ * Created by vblagodarov on 09-08-17.
+ */
+public abstract class EditLibraryEntryAction<T extends Entry> extends AbstractAction {
+
+    private JTree tree;
+    private OntologyLibraryPanel.JTreeRefresh refreshAction;
+    private DefaultMutableTreeNode node;
+    private XMLCatalog catalog;
+    private String title;
+
+    public EditLibraryEntryAction(String windowTitle, JTree parent, DefaultMutableTreeNode selectedNode, XMLCatalog catalog, OntologyLibraryPanel.JTreeRefresh action) {
+        super("Edit Library Entry");
+        tree = parent;
+        node = selectedNode;
+        this.catalog = catalog;
+        refreshAction = action;
+        title = windowTitle;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        T entry = (T) node.getUserObject();
+        ILibraryEntryEditor<T> entryEditor = getNewEditorPanel(entry);
+        final JButton ok = new JButton("OK");
+        ok.setEnabled(true);
+        ok.addActionListener(e1 -> {
+            Window w = SwingUtilities.getWindowAncestor(ok);
+            if (w != null) {
+                w.setVisible(false);
+                T edited = entryEditor.getEntry(entry);
+                if (edited == null) {
+                    return;
+                }
+                try {
+                    catalog.replaceEntry(entry, edited);
+                    node.setUserObject(edited);
+                    refreshAction.refreshView();
+                } catch (Exception ex) {
+                    LoggerFactory.getLogger(EditUriAction.class)
+                            .error("An error occurred while updating the catalog entry", ex);
+                }
+            }
+        });
+        entryEditor.addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                ok.setEnabled(entryEditor.isInputValid());
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                ok.setEnabled(entryEditor.isInputValid());
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                ok.setEnabled(entryEditor.isInputValid());
+            }
+        });
+
+        JOptionPane.showOptionDialog(tree, entryEditor.getComponent(), title, JOptionPane.NO_OPTION, JOptionPane.PLAIN_MESSAGE, null, new JButton[]{ok}, ok);
+    }
+
+    protected abstract ILibraryEntryEditor<T> getNewEditorPanel(T entry);
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/EditNextCatalogAction.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/EditNextCatalogAction.java
@@ -1,0 +1,22 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.NextCatalogEntry;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+
+/**
+ * Created by vblagodarov on 08-08-17.
+ */
+public class EditNextCatalogAction extends EditLibraryEntryAction<NextCatalogEntry> {
+
+    public EditNextCatalogAction(JTree parent, DefaultMutableTreeNode selectedNode, XMLCatalog catalog, OntologyLibraryPanel.JTreeRefresh action) {
+        super("Next catalog physical location", parent, selectedNode, catalog, action);
+    }
+
+    @Override
+    protected ILibraryEntryEditor<NextCatalogEntry> getNewEditorPanel(NextCatalogEntry entry) {
+        return new NextCatalogEntryEditorPanel(entry);
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/EditRewriteUriAction.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/EditRewriteUriAction.java
@@ -1,0 +1,21 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.RewriteUriEntry;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+
+/**
+ * Created by vblagodarov on 09-08-17.
+ */
+public class EditRewriteUriAction extends EditLibraryEntryAction<RewriteUriEntry> {
+    public EditRewriteUriAction(JTree parent, DefaultMutableTreeNode selectedNode, XMLCatalog catalog, OntologyLibraryPanel.JTreeRefresh action) {
+        super("Rewrite uri entry", parent, selectedNode, catalog, action);
+    }
+
+    @Override
+    protected ILibraryEntryEditor<RewriteUriEntry> getNewEditorPanel(RewriteUriEntry entry) {
+        return new RewriteUriEntryEditorPanel(entry);
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/ILibraryEntryEditor.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/ILibraryEntryEditor.java
@@ -1,0 +1,19 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.xmlcatalog.entry.Entry;
+
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+
+/**
+ * Created by vblagodarov on 10-08-17.
+ */
+public interface ILibraryEntryEditor<T extends Entry> {
+    T getEntry(T oldEntry);
+
+    boolean isInputValid();
+
+    void addDocumentListener(DocumentListener documentListener);
+
+    Component getComponent();
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/NewEntryPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/NewEntryPanel.java
@@ -3,13 +3,18 @@ package org.protege.editor.owl.ui.library;
 import org.protege.xmlcatalog.entry.Entry;
 
 import javax.swing.*;
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public abstract class NewEntryPanel extends JPanel {
 	private static final long serialVersionUID = -706694344158933046L;
+
+	private static final Dimension defaultTextField = new JTextField("/some/unknown/path/dont/really/care/about-it.owl").getPreferredSize();
 	
 	private List<Runnable> listeners = new ArrayList<>();
+
 
 	public abstract Entry getEntry();
 	
@@ -24,10 +29,18 @@ public abstract class NewEntryPanel extends JPanel {
 	public void clearListeners() {
 		listeners.clear();
 	}
+
+	public static Dimension getDefaultTextFieldDimension(){
+		return defaultTextField;
+	}
 	
 	protected void fireListeners() {
 		for (Runnable r : listeners) {
 			r.run();
 		}
+	}
+
+	protected String getUniqueId(){
+		return UUID.randomUUID().toString();
 	}
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/NextCatalogEntryEditorPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/NextCatalogEntryEditorPanel.java
@@ -1,0 +1,108 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.editor.owl.ui.library.plugins.NextCatalogPanel;
+import org.protege.xmlcatalog.CatalogUtilities;
+import org.protege.xmlcatalog.XmlBaseContext;
+import org.protege.xmlcatalog.entry.NextCatalogEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by vblagodarov on 09-08-17.
+ */
+public class NextCatalogEntryEditorPanel implements ILibraryEntryEditor<NextCatalogEntry> {
+
+    private JPanel mainComponent;
+    private XmlBaseContext baseContext;
+    private JTextField physicalLocation;
+    private final Logger logger = LoggerFactory.getLogger(NextCatalogEntryEditorPanel.class);
+
+    public NextCatalogEntryEditorPanel(XmlBaseContext context) {
+        baseContext = context;
+        initMainComponent("");
+    }
+
+    public NextCatalogEntryEditorPanel(NextCatalogEntry entry) {
+        baseContext = entry.getXmlBaseContext();
+        if (entry != null && entry.getCatalog() != null) {
+            initMainComponent(entry.getCatalog().toString());
+        } else {
+            initMainComponent("");
+        }
+    }
+
+    public NextCatalogEntryEditorPanel(XmlBaseContext context, DocumentListener changeLocationListener) {
+        this(context);
+        addDocumentListener(changeLocationListener);
+    }
+
+    private void initMainComponent(String defaultValue) {
+        mainComponent = new JPanel(new FlowLayout(FlowLayout.LEADING));
+        physicalLocation = new JTextField();
+        physicalLocation.setText(defaultValue);
+
+        physicalLocation.setPreferredSize(NextCatalogPanel.getDefaultTextFieldDimension());
+        mainComponent.add(physicalLocation);
+
+        JButton fileButton = new JButton("Browse");
+        fileButton.addActionListener(new ChooseFileAction(mainComponent, baseContext, physicalLocation));
+        mainComponent.add(fileButton);
+    }
+
+    public void addDocumentListener(DocumentListener documentListener) {
+        physicalLocation.getDocument().addDocumentListener(documentListener);
+    }
+
+    public Component getComponent() {
+        return mainComponent;
+    }
+
+    public NextCatalogEntry getEntry(String id, URI baseUri) {
+        if (!isInputValid()) {
+            return null;
+        }
+        URI physicalLocationUri = getPhysicalLocation();
+        URI base = CatalogUtilities.resolveXmlBase(baseContext);
+        return new NextCatalogEntry(id,
+                baseContext,
+                base == null ? physicalLocationUri : base.relativize(physicalLocationUri),
+                baseUri);
+    }
+
+    public NextCatalogEntry getEntry(NextCatalogEntry oldEntry) {
+        return isInputValid() ? getEntry(oldEntry.getId(), oldEntry.getXmlBase()) : null;
+    }
+
+    @Override
+    public boolean isInputValid() {
+        return getPhysicalLocation() != null;
+    }
+
+    private URI getPhysicalLocation() {
+        String text = physicalLocation.getText();
+        if (text == null) {
+            return null;
+        }
+        text = text.trim();
+        if (text.isEmpty()) {
+            return null;
+        }
+        try {
+            if (new File(text).exists()) {
+                return new File(text).toURI();
+            } else {
+                return new URI(text);
+            }
+        } catch (URISyntaxException ex) {
+            logger.error("Could not parse URL: {}.", text, ex);
+        }
+        return null;
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/RewriteUriEntryEditorPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/RewriteUriEntryEditorPanel.java
@@ -1,0 +1,103 @@
+package org.protege.editor.owl.ui.library;
+
+import org.protege.xmlcatalog.XmlBaseContext;
+import org.protege.xmlcatalog.entry.RewriteUriEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by vblagodarov on 09-08-17.
+ */
+public class RewriteUriEntryEditorPanel implements ILibraryEntryEditor<RewriteUriEntry> {
+
+    private JPanel mainComponent;
+    private XmlBaseContext baseContext;
+    private JTextField startPrefix;
+    private JTextField rewriteByURI;
+    private final Logger logger = LoggerFactory.getLogger(RewriteUriEntryEditorPanel.class);
+
+    public RewriteUriEntryEditorPanel(XmlBaseContext context) {
+        baseContext = context;
+        initMainComponent("", "");
+    }
+
+    public RewriteUriEntryEditorPanel(RewriteUriEntry entry) {
+        baseContext = entry.getXmlBaseContext();
+        if (entry != null) {
+            initMainComponent(entry.getUriStartString(), entry.getRewritePrefix().toString());
+        } else {
+            initMainComponent("", "");
+        }
+    }
+
+    public RewriteUriEntryEditorPanel(XmlBaseContext context, DocumentListener changeStartPrefixListener) {
+        this(context);
+        addDocumentListener(changeStartPrefixListener);
+    }
+
+    public RewriteUriEntry getEntry(String id) {
+        if (!isInputValid()) {
+            return null;
+        }
+        String rewrite = rewriteByURI.getText().trim();
+        try {
+            return new RewriteUriEntry(id, baseContext, startPrefix.getText().trim(), rewrite == null ? new URI("") : new URI(rewrite));
+        } catch (URISyntaxException e) {
+            logger.error("Rewrite prefix is not a valid URI: {}.", rewrite == null ? "<null>" : rewrite, e);
+        }
+        return null;
+    }
+
+    @Override
+    public RewriteUriEntry getEntry(RewriteUriEntry oldEntry) {
+        return isInputValid() ? getEntry(oldEntry.getId()) : null;
+    }
+
+    @Override
+    public boolean isInputValid() {
+        String prefix = startPrefix.getText();
+        if (prefix == null) {
+            return false;
+        }
+        return !(prefix.trim().isEmpty());
+    }
+
+    @Override
+    public void addDocumentListener(DocumentListener documentListener) {
+        startPrefix.getDocument().addDocumentListener(documentListener);
+    }
+
+    public Component getComponent() {
+        return mainComponent;
+    }
+
+    private void initMainComponent(String defaultPrefix, String defaultRewrite) {
+        mainComponent = new JPanel();
+        mainComponent.setLayout(new BoxLayout(mainComponent, BoxLayout.Y_AXIS));
+
+        JPanel start = new JPanel();
+        start.setLayout(new FlowLayout(FlowLayout.LEADING));
+        start.add(new JLabel("Start prefix: "));
+        startPrefix = new JTextField();
+        startPrefix.setText(defaultPrefix);
+        startPrefix.setPreferredSize(NewEntryPanel.getDefaultTextFieldDimension());
+        rewriteByURI = new JTextField();
+        rewriteByURI.setText(defaultRewrite);
+        rewriteByURI.setPreferredSize(NewEntryPanel.getDefaultTextFieldDimension());
+        start.add(startPrefix);
+
+        JPanel rewrite = new JPanel();
+        rewrite.setLayout(new FlowLayout(FlowLayout.LEADING));
+        rewrite.add(new JLabel("Rewrite by: "));
+        rewrite.add(rewriteByURI);
+
+        mainComponent.add(start);
+        mainComponent.add(rewrite);
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/FolderGroupPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/FolderGroupPanel.java
@@ -38,7 +38,7 @@ public class FolderGroupPanel extends NewEntryPanel {
         physicalLocationPanel.setLayout(new FlowLayout());
         physicalLocationPanel.add(new JLabel("Directory: "));
         physicalLocationField = new JTextField();
-        physicalLocationField.setPreferredSize(new JTextField("/home/tredmond/Shared/ontologies/simple/pizza-good.owl").getPreferredSize());
+        physicalLocationField.setPreferredSize(getDefaultTextFieldDimension());
         physicalLocationField.addActionListener(e -> {
             fireListeners();
         });

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/NextCatalogPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/NextCatalogPanel.java
@@ -1,0 +1,47 @@
+package org.protege.editor.owl.ui.library.plugins;
+
+import org.protege.editor.owl.ui.library.NewEntryPanel;
+import org.protege.editor.owl.ui.library.NextCatalogEntryEditorPanel;
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.NextCatalogEntry;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+
+/**
+ * Created by vblagodarov on 02-08-17.
+ */
+public class NextCatalogPanel extends NewEntryPanel {
+
+    private static final long serialVersionUID = 3696300927123324406L;
+    private XMLCatalog catalog;
+    NextCatalogEntryEditorPanel catalogEntryPanel;
+
+    public NextCatalogPanel(XMLCatalog xmlCatalog){
+        catalog = xmlCatalog;
+        setLayout(new BorderLayout());
+        catalogEntryPanel = new NextCatalogEntryEditorPanel(catalog, new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                fireListeners();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                fireListeners();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                fireListeners();
+            }
+        });
+        add(catalogEntryPanel.getComponent());
+        fireListeners();
+    }
+
+    @Override
+    public NextCatalogEntry getEntry() {
+        return catalogEntryPanel.getEntry(getUniqueId() , null);
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/RewriteUriEntryPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/RewriteUriEntryPanel.java
@@ -1,0 +1,45 @@
+package org.protege.editor.owl.ui.library.plugins;
+
+import org.protege.editor.owl.ui.library.NewEntryPanel;
+import org.protege.editor.owl.ui.library.RewriteUriEntryEditorPanel;
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.RewriteUriEntry;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+
+/**
+ * Created by vblagodarov on 03-08-17.
+ */
+public class RewriteUriEntryPanel extends NewEntryPanel {
+    private static final long serialVersionUID = -1338724727207898549L;
+    private XMLCatalog catalog;
+    private RewriteUriEntryEditorPanel rewriteEditorPanel;
+
+    public RewriteUriEntryPanel(XMLCatalog xmlCatalog){
+        catalog = xmlCatalog;
+        setLayout(new BorderLayout());
+        rewriteEditorPanel = new RewriteUriEntryEditorPanel(catalog, new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                fireListeners();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                fireListeners();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                fireListeners();
+            }
+        });
+        add(rewriteEditorPanel.getComponent());
+    }
+
+    @Override
+    public RewriteUriEntry getEntry() {
+        return rewriteEditorPanel.getEntry(getUniqueId());
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/UriEntryPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/library/plugins/UriEntryPanel.java
@@ -15,8 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -49,7 +47,7 @@ public class UriEntryPanel extends NewEntryPanel {
         physicalLocationPanel.setLayout(new FlowLayout());
         physicalLocationPanel.add(new JLabel("Physical Location: "));
         physicalLocationField = new JTextField();
-        physicalLocationField.setPreferredSize(new JTextField("/home/tredmond/Shared/ontologies/simple/pizza-good.owl").getPreferredSize());
+        physicalLocationField.setPreferredSize(getDefaultTextFieldDimension());
         physicalLocationPanel.add(physicalLocationField);
         JButton browse = new JButton("Browse");
         browse.addActionListener(e -> {
@@ -152,7 +150,7 @@ public class UriEntryPanel extends NewEntryPanel {
             return null;
         }
         physicalLocation = CatalogUtilities.relativize(physicalLocation, catalog);
-        return new UriEntry("User Edited Redirect",
+        return new UriEntry(getUniqueId(),
                 catalog,
                 importDeclarationString,
                 physicalLocation,

--- a/protege-editor-owl/src/main/resources/plugin.xml
+++ b/protege-editor-owl/src/main/resources/plugin.xml
@@ -1383,6 +1383,14 @@
 		<class value="org.protege.editor.owl.model.library.UriEntryManager"/>
 	</extension>
 
+    <extension id="NextCatalogEntry" point="org.protege.editor.owl.repository">
+        <class value="org.protege.editor.owl.model.library.NextCatalogManager"/>
+    </extension>
+
+    <extension id="RewriteUriEntry" point="org.protege.editor.owl.repository">
+        <class value="org.protege.editor.owl.model.library.RewriteUriEntryManager"/>
+    </extension>
+
     <!-- Species validation -->
 
 


### PR DESCRIPTION
Ontology libraries (Catalog)  editor improvements:
1)	Add new entries:  add support for nextcatalog and rewriteUri entries
2)	Catalog displayed tree: fix (mostly implement) possibility to Edit and Delete entries for UriEntry, nextCatalog and rewriteUri entries.
Requires recent  changes from xmlcatalog project: to be precise the change e780028665d4c7ff6760c177083ebc510d23cb63 (the merge of my branch) 
