### PR TITLE
Fixes #678 : Protege crashes when closing all the tabs

### DIFF
--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/tabbedpane/CloseableTabbedPaneUI.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/tabbedpane/CloseableTabbedPaneUI.java
@@ -263,6 +263,9 @@ public class CloseableTabbedPaneUI extends BasicTabbedPaneUI {
 
 
     public Rectangle getTabBounds(JTabbedPane pane, int i) {
+        if (i < 0){
+            return new Rectangle(0,0);
+        }
         Rectangle tabBounds = super.getTabBounds(pane, i);
         tabBounds.height = getTabHeight();
         return tabBounds;


### PR DESCRIPTION
Protege crashes on closing the last available tab (=> no more open tabs left)