### PR TITLE
Rules sorting

### DIFF
--- a/protege-editor-core/src/main/resources/plugin.xml
+++ b/protege-editor-core/src/main/resources/plugin.xml
@@ -214,6 +214,22 @@
         <editorKitId value="any"/>
     </extension>
 
+    <extension id="menu.window.timestamp" point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Timestamp log / console"/>
+        <path value="org.protege.editor.core.application.menu.window/SlotE-A"/>
+        <toolTip value="Prints a timestamp and optional message into the logs or console"/>
+        <class value="org.protege.editor.core.ui.action.TimestampOutputAction"/>
+        <editorKitId value="any"/>
+    </extension>
+
+    <extension id="menu.window.showlog" point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Show log..."/>
+        <path value="org.protege.editor.core.application.menu.window/SlotE-B"/>
+        <toolTip value="Prints a timestamp and optional message into the logs or console"/>
+        <class value="org.protege.editor.core.log.ShowLogAction"/>
+        <editorKitId value="any"/>
+    </extension>
+
     <!-- Help menu -->
 
     <extension id="menu.HelpMenu" point="org.protege.editor.core.application.EditorKitMenuAction">
@@ -259,30 +275,6 @@
                point="org.protege.editor.core.application.preferencespanel">
         <label value="Plugins"/>
         <class value="org.protege.editor.core.update.PluginPreferencesPanel"/>
-    </extension>
-    
-    <!-- Log preferences -->
-    
-    <extension id="ui.preferences.update"
-               point="org.protege.editor.core.application.preferencespanel">
-        <label value="Log"/>
-        <class value="org.protege.editor.core.log.LogPreferencesPanel"/>
-    </extension>
-
-    <extension id="menu.window.timestamp" point="org.protege.editor.core.application.EditorKitMenuAction">
-        <name value="Timestamp log / console"/>
-        <path value="org.protege.editor.core.application.menu.window/SlotE-A"/>
-        <toolTip value="Prints a timestamp and optional message into the logs or console"/>
-        <class value="org.protege.editor.core.ui.action.TimestampOutputAction"/>
-        <editorKitId value="any"/>
-    </extension>
-
-    <extension id="menu.window.showlog" point="org.protege.editor.core.application.EditorKitMenuAction">
-        <name value="Show log..."/>
-        <path value="org.protege.editor.core.application.menu.window/SlotE-B"/>
-        <toolTip value="Prints a timestamp and optional message into the logs or console"/>
-        <class value="org.protege.editor.core.log.ShowLogAction"/>
-        <editorKitId value="any"/>
     </extension>
     
     <!-- Other startup actions --> 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/swrl/SWRLRulePreferences.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/swrl/SWRLRulePreferences.java
@@ -1,0 +1,41 @@
+package org.protege.editor.owl.model.swrl;
+
+import org.protege.editor.core.prefs.Preferences;
+import org.protege.editor.core.prefs.PreferencesManager;
+
+public class SWRLRulePreferences {
+
+	private static SWRLRulePreferences instance;
+
+	private static final String SWRL_RULE_PREFS_KEY = "SWRL_RULE_PREFS";
+	
+	private static final String SORT_ON_ANN_PRP_KEY = "SORT_ON_ANN_PRP";
+	private static final String SHOW_ANN_PRP_WITH_RULE_KEY = "SHOW_ANN_PRP_WITH_RULE";
+	
+	public static SWRLRulePreferences getInstance() {
+		if (instance == null)
+			instance = new SWRLRulePreferences();
+		
+		return instance;
+	}
+	
+    private static Preferences getPreferences() {
+        return PreferencesManager.getInstance().getApplicationPreferences(SWRL_RULE_PREFS_KEY);
+    }
+
+    public boolean getSortRulesOnAnnPrp() {
+    	return getPreferences().getBoolean(SORT_ON_ANN_PRP_KEY, false);
+    }
+    
+    public void setSortRulesOnAnnPrp(boolean sort) {
+    	getPreferences().putBoolean(SORT_ON_ANN_PRP_KEY, sort);
+    }
+    
+    public boolean getShowAnnPrpWithRule() {
+    	return getPreferences().getBoolean(SHOW_ANN_PRP_WITH_RULE_KEY, false);
+    }
+    
+    public void setShowAnnPrpWithRule(boolean show) {
+    	getPreferences().putBoolean(SHOW_ANN_PRP_WITH_RULE_KEY, show);
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/AbstractOWLFrameSectionRow.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/AbstractOWLFrameSectionRow.java
@@ -35,7 +35,7 @@ public abstract class AbstractOWLFrameSectionRow<R extends Object, A extends OWL
 
     private Object userObject;
 
-    private OWLFrameSection section;
+    protected OWLFrameSection section;
 
     protected AbstractOWLFrameSectionRow(OWLEditorKit owlEditorKit, OWLFrameSection<R,A,E> section, OWLOntology ontology,
                                          R rootObject, A axiom) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/AnnotatedSWRLRuleFrameSectionRow.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/AnnotatedSWRLRuleFrameSectionRow.java
@@ -1,0 +1,60 @@
+package org.protege.editor.owl.ui.frame;
+
+import java.util.Iterator;
+
+import org.protege.editor.owl.OWLEditorKit;
+import org.protege.editor.owl.model.swrl.SWRLRulePreferences;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLObject;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.SWRLRule;
+
+/*
+ * 
+ * 
+ * @author wvw
+ * 
+ */
+
+public class AnnotatedSWRLRuleFrameSectionRow extends SWRLRuleFrameSectionRow {
+
+	public AnnotatedSWRLRuleFrameSectionRow(OWLEditorKit owlEditorKit,
+			OWLFrameSection<OWLOntology, SWRLRule, SWRLRule> section, OWLOntology ontology, OWLOntology rootObject,
+			SWRLRule axiom) {
+
+		super(owlEditorKit, section, ontology, rootObject, axiom);
+	}
+
+	@Override
+	public String getRendering() {
+		SWRLRulePreferences prefs = SWRLRulePreferences.getInstance();
+		if (!prefs.getShowAnnPrpWithRule())
+			return super.getRendering();
+		
+		StringBuilder sb = new StringBuilder();
+
+		OWLAnnotation ann = SWRLRuleUtils.findAnnotation(axiom.getAnnotations());
+		if (ann != null) {
+			String value = ann.getValue().asLiteral().get().getLiteral();
+
+			sb.append("<demph>").append(value).append("</demph> = ");
+		}
+
+		for (Iterator<? extends OWLObject> it = getManipulatableObjects().iterator(); it.hasNext();) {
+			OWLObject obj = it.next();
+			sb.append(getObjectRendering(obj));
+			if (it.hasNext()) {
+				sb.append(getDelimeter());
+			}
+		}
+		sb.append(getSuffix());
+
+		return sb.toString();
+	}
+
+	// TODO
+	@Override
+	public String getTooltip() {
+		return null;
+	}
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SWRLRuleUtils.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SWRLRuleUtils.java
@@ -1,0 +1,14 @@
+package org.protege.editor.owl.ui.frame;
+
+import java.util.Set;
+
+import org.semanticweb.owlapi.model.OWLAnnotation;
+
+public class SWRLRuleUtils {
+
+	public static OWLAnnotation findAnnotation(Set<OWLAnnotation> annotations) {
+		return annotations.stream()
+				.filter(a -> a.getProperty().getIRI().toString().equals("http://www.w3.org/2000/01/rdf-schema#comment"))
+				.findAny().orElse(null);
+	}
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SWRLRulesFrame.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SWRLRulesFrame.java
@@ -7,19 +7,23 @@ import org.semanticweb.owlapi.model.OWLOntology;
  *
  *
  */
-
+import org.semanticweb.owlapi.model.OWLOntologyManager;
 
 /**
  * Author: Matthew Horridge<br>
  * The University Of Manchester<br>
  * Bio-Health Informatics Group<br>
- * Date: 06-Jul-2007<br><br>
+ * Date: 06-Jul-2007<br>
+ * <br>
  */
 public class SWRLRulesFrame extends AbstractOWLFrame<OWLOntology> {
 
+	public SWRLRulesFrame(OWLEditorKit editorKit) {
+		super(editorKit.getModelManager().getOWLOntologyManager());
+		addSection(new SWRLRulesFrameSection(editorKit, this));
+	}
 
-    public SWRLRulesFrame(OWLEditorKit editorKit) {
-        super(editorKit.getModelManager().getOWLOntologyManager());
-        addSection(new SWRLRulesFrameSection(editorKit, this));
-    }
+	public SWRLRulesFrame(OWLOntologyManager owlOntologyManager) {
+		super(owlOntologyManager);
+	}
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SWRLRulesFrameSection.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SWRLRulesFrameSection.java
@@ -1,5 +1,7 @@
 package org.protege.editor.owl.ui.frame;
 
+import java.util.Comparator;
+
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.ui.editor.OWLObjectEditor;
 import org.protege.editor.owl.ui.editor.SWRLRuleEditor;
@@ -8,66 +10,61 @@ import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.SWRLRule;
 
-import java.util.Comparator;
-
-
 /*
  * Copyright (C) 2007, University of Manchester
  *
  *
  */
 
-
 /**
  * Author: Matthew Horridge<br>
  * The University Of Manchester<br>
  * Bio-Health Informatics Group<br>
- * Date: 06-Jul-2007<br><br>
+ * Date: 06-Jul-2007<br>
+ * <br>
  */
 public class SWRLRulesFrameSection extends AbstractOWLFrameSection<OWLOntology, SWRLRule, SWRLRule> {
 
+	public SWRLRulesFrameSection(OWLEditorKit editorKit, OWLFrame<? extends OWLOntology> owlFrame) {
+		super(editorKit, "Rules", "Rule", owlFrame);
+	}
 
-    public SWRLRulesFrameSection(OWLEditorKit editorKit, OWLFrame<? extends OWLOntology> owlFrame) {
-        super(editorKit, "Rules", "Rule", owlFrame);
-    }
+	protected SWRLRulesFrameSection(OWLEditorKit editorKit, String label, String rowLabel,
+			OWLFrame<? extends OWLOntology> frame) {
 
+		super(editorKit, label, rowLabel, frame);
+	}
 
-    protected SWRLRule createAxiom(SWRLRule object) {
-        return object;
-    }
+	protected SWRLRule createAxiom(SWRLRule object) {
+		return object;
+	}
 
+	public OWLObjectEditor<SWRLRule> getObjectEditor() {
+		return new SWRLRuleEditor(getOWLEditorKit());
+	}
 
-    public OWLObjectEditor<SWRLRule> getObjectEditor() {
-        return new SWRLRuleEditor(getOWLEditorKit());
-    }
+	public boolean canAdd() {
+		return true;
+	}
 
+	protected void refill(OWLOntology ontology) {
+		for (SWRLRule rule : ontology.getAxioms(AxiomType.SWRL_RULE))
+			addRow(new AnnotatedSWRLRuleFrameSectionRow(getOWLEditorKit(), this, ontology, ontology, rule));
+	}
 
-    public boolean canAdd() {
-        return true;
-    }
+	protected void clear() {
+	}
 
+	public Comparator<OWLFrameSectionRow<OWLOntology, SWRLRule, SWRLRule>> getRowComparator() {
+		return null;
+	}
 
-    protected void refill(OWLOntology ontology) {
-        for (SWRLRule rule : ontology.getAxioms(AxiomType.SWRL_RULE)) {
-            addRow(new SWRLRuleFrameSectionRow(getOWLEditorKit(), this, ontology, ontology, rule));
-        }
-    }
-
-
-    protected void clear() {
-    }
-
-
-    public Comparator<OWLFrameSectionRow<OWLOntology, SWRLRule, SWRLRule>> getRowComparator() {
-        return null;
-    }
-
-    @Override
-    protected boolean isResettingChange(OWLOntologyChange change) {
-    	if (!change.isAxiomChange()) {
-    		return false;
-    	}
-    	return change.getAxiom() instanceof SWRLRule;
-    }
+	@Override
+	protected boolean isResettingChange(OWLOntologyChange change) {
+		if (!change.isAxiomChange()) {
+			return false;
+		}
+		return change.getAxiom() instanceof SWRLRule;
+	}
 
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SortedSWRLRulesFrame.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SortedSWRLRulesFrame.java
@@ -1,0 +1,20 @@
+package org.protege.editor.owl.ui.frame;
+
+import org.protege.editor.owl.OWLEditorKit;
+
+/**
+ * 
+ * 
+ * @author wvw
+ *
+ */
+
+public class SortedSWRLRulesFrame extends SWRLRulesFrame {
+
+	// when passing editorKit as a whole to super constructor,
+	// sorting doesn't work
+	public SortedSWRLRulesFrame(OWLEditorKit editorKit) {
+		super(editorKit.getModelManager().getOWLOntologyManager());
+		addSection(new SortedSWRLRulesFrameSection(editorKit, this));
+	}
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SortedSWRLRulesFrameSection.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/SortedSWRLRulesFrameSection.java
@@ -1,0 +1,76 @@
+package org.protege.editor.owl.ui.frame;
+
+import java.util.Comparator;
+
+import org.protege.editor.owl.OWLEditorKit;
+import org.protege.editor.owl.model.swrl.SWRLRulePreferences;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.SWRLRule;
+
+/**
+ * 
+ * 
+ * @author wvw
+ *
+ */
+
+public class SortedSWRLRulesFrameSection extends SWRLRulesFrameSection {
+
+	public SortedSWRLRulesFrameSection(OWLEditorKit editorKit, OWLFrame<? extends OWLOntology> owlFrame) {
+		super(editorKit, owlFrame);
+	}
+
+	protected SortedSWRLRulesFrameSection(OWLEditorKit editorKit, String label, String rowLabel,
+			OWLFrame<? extends OWLOntology> frame) {
+
+		super(editorKit, label, rowLabel, frame);
+	}
+
+	@Override
+	public Comparator<OWLFrameSectionRow<OWLOntology, SWRLRule, SWRLRule>> getRowComparator() {
+		SWRLRulePreferences prefs = SWRLRulePreferences.getInstance();
+
+		if (!prefs.getSortRulesOnAnnPrp())
+			return null;
+
+		return new Comparator<OWLFrameSectionRow<OWLOntology, SWRLRule, SWRLRule>>() {
+
+			@Override
+			public int compare(OWLFrameSectionRow<OWLOntology, SWRLRule, SWRLRule> o1,
+					OWLFrameSectionRow<OWLOntology, SWRLRule, SWRLRule> o2) {
+
+				return cmp(o1.getAxiom(), o2.getAxiom());
+			}
+		};
+	}
+
+	private int cmp(SWRLRule rule1, SWRLRule rule2) {
+		OWLAnnotation ann1 = SWRLRuleUtils.findAnnotation(rule1.getAnnotations());
+		OWLAnnotation ann2 = SWRLRuleUtils.findAnnotation(rule2.getAnnotations());
+
+		// if both comments are null, rule1 == rule2
+		// if comment1 is null, rule1 > rule2 (i.e., put rule1 at the back)
+		// if comment2 is null, rule2 > rule1 (i.e., put rule2 at the back)
+		if (ann1 == null) {
+			if (ann2 == null)
+				return 0;
+			else
+				return 1;
+
+		} else {
+			if (ann2 == null)
+				return -1;
+		}
+
+		String value1 = ann1.getValue().asLiteral().get().getLiteral();
+		String value2 = ann2.getValue().asLiteral().get().getLiteral();
+
+		return doCmp(value1, value2);
+	}
+
+	// hook for subclasses
+	protected int doCmp(String value1, String value2) {
+		return value1.compareTo(value2);
+	}
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/framelist/OWLFrameList.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/framelist/OWLFrameList.java
@@ -105,6 +105,10 @@ public class OWLFrameList<R> extends MList implements LinkedObjectComponent, Dro
 
 
     public OWLFrameList(OWLEditorKit editorKit, OWLFrame<R> frame) {
+		this(editorKit, frame, true, true);
+	}
+
+	public OWLFrameList(OWLEditorKit editorKit, OWLFrame<R> frame, boolean showExplainBtn, boolean showAnnotBtn) {
         this.editorKit = editorKit;
         this.frame = frame;
 
@@ -134,9 +138,11 @@ public class OWLFrameList<R> extends MList implements LinkedObjectComponent, Dro
         createPopupMenu();
 
         inferredRowButtons = new ArrayList<>();
-        inferredRowButtons.add(new ExplainButton(e -> invokeExplanationHandler()));
+        if (showExplainBtn)
+			inferredRowButtons.add(new ExplainButton(e -> invokeExplanationHandler()));
 
-        axiomAnnotationButton = new AxiomAnnotationButton(event -> invokeAxiomAnnotationHandler());
+		if (showAnnotBtn)
+			axiomAnnotationButton = new AxiomAnnotationButton(event -> invokeAxiomAnnotationHandler());
 
         changeListenerMediator = new ChangeListenerMediator();
         addListSelectionListener(selListener);

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/preferences/SWRLRulePreferencesPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/preferences/SWRLRulePreferencesPanel.java
@@ -1,0 +1,57 @@
+package org.protege.editor.owl.ui.preferences;
+
+import java.awt.BorderLayout;
+
+import javax.swing.JCheckBox;
+
+import org.protege.editor.core.ui.preferences.PreferencesLayoutPanel;
+import org.protege.editor.owl.model.swrl.SWRLRulePreferences;
+import org.protege.editor.owl.ui.view.SWRLRulesViewComponent;
+
+/**
+ * 
+ * 
+ * @author wvw
+ *
+ */
+
+public class SWRLRulePreferencesPanel extends OWLPreferencesPanel {
+
+	private static final long serialVersionUID = 1L;
+
+	private JCheckBox sortRulesOnAnnPrpCheckBox;
+	private JCheckBox showAnnPrpWithRuleCheckBox;
+
+	@Override
+	public void initialise() throws Exception {
+		setLayout(new BorderLayout());
+
+		PreferencesLayoutPanel panel = new PreferencesLayoutPanel();
+		add(panel, BorderLayout.NORTH);
+		panel.addGroup("Display");
+
+		SWRLRulePreferences prefs = SWRLRulePreferences.getInstance();
+
+		sortRulesOnAnnPrpCheckBox = new JCheckBox("Sort rules based on rdfs:comment", prefs.getSortRulesOnAnnPrp());
+		panel.addGroupComponent(sortRulesOnAnnPrpCheckBox);
+
+		showAnnPrpWithRuleCheckBox = new JCheckBox("Show rdfs:comment with rule", prefs.getShowAnnPrpWithRule());
+		panel.addGroupComponent(showAnnPrpWithRuleCheckBox);
+	}
+
+	@Override
+	public void dispose() throws Exception {
+	}
+
+	@Override
+	public void applyChanges() {
+		SWRLRulePreferences prefs = SWRLRulePreferences.getInstance();
+
+		prefs.setSortRulesOnAnnPrp(sortRulesOnAnnPrpCheckBox.isSelected());
+		prefs.setShowAnnPrpWithRule(showAnnPrpWithRuleCheckBox.isSelected());
+
+		// TODO has no effect on sorting of already shown rule list
+		// getOWLEditorKit().getOWLWorkspace().refreshComponents();
+		SWRLRulesViewComponent.preferencesUpdated();
+	}
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
@@ -743,6 +743,10 @@ public class OWLCellRenderer implements TableCellRenderer, TreeCellRenderer, Lis
             theVal = theVal.replace('\n', ' ');
             theVal = theVal.replaceAll(" [ ]+", " ");
         }
+        
+		TheValueStyler theStyler = new TheValueStyler();
+		theVal = theStyler.processTheValue(theVal);
+        
         textPane.setText(theVal);
         if (commentedOut) {
             textPane.setText(textPane.getText());
@@ -811,6 +815,8 @@ public class OWLCellRenderer implements TableCellRenderer, TreeCellRenderer, Lis
                 doc.setCharacterAttributes(0, doc.getLength(), selectionForeground, false);
             }
         }
+        
+        theStyler.applyTheValueStyles(doc);
     }
 
 
@@ -1327,4 +1333,47 @@ public class OWLCellRenderer implements TableCellRenderer, TreeCellRenderer, Lis
             }
         }
     }
+    
+    private class TheValueStyler {
+
+		private String[] tagNames = { "demph" };
+		private Style[] styles = { feintStyle };
+
+		private List<Integer> startIdxs = new ArrayList<>();
+		private List<Integer> endIdxs = new ArrayList<>();
+		private List<Style> foundStyles = new ArrayList<>();
+
+		public String processTheValue(String theVal) {
+			for (int i = 0; i < tagNames.length; i++) {
+				String tagName = tagNames[i];
+				String startTag = "<" + tagName + ">";
+				String endTag = "</" + tagName + ">";
+
+				while (theVal.contains(startTag)) {
+					int startIdx = theVal.indexOf(startTag);
+					int endIdx = theVal.indexOf(endTag, startIdx);
+
+					theVal = theVal.substring(0, startIdx)
+							+ theVal.substring(startIdx + startTag.length(), endIdx)
+							+ theVal.substring(endIdx + endTag.length());
+					
+					startIdxs.add(startIdx);
+					endIdxs.add(endIdx - startTag.length());
+					foundStyles.add(styles[i]);
+				}
+			}
+
+			return theVal;
+		}
+
+		public void applyTheValueStyles(StyledDocument doc) {
+			for (int i = 0; i < startIdxs.size(); i++) {
+				int startIdx = startIdxs.get(i);
+				int endIdx = endIdxs.get(i);
+				Style style = foundStyles.get(i);
+
+				doc.setCharacterAttributes(startIdx, endIdx - startIdx, style, false);
+			}
+		}
+	}
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/SWRLRulesViewComponent.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/SWRLRulesViewComponent.java
@@ -1,51 +1,71 @@
 package org.protege.editor.owl.ui.view;
 
-import org.protege.editor.owl.ui.frame.SWRLRulesFrame;
-import org.protege.editor.owl.ui.framelist.OWLFrameList;
-import org.semanticweb.owlapi.model.OWLOntology;
-
-import javax.swing.*;
-import java.awt.*;
 /*
  * Copyright (C) 2007, University of Manchester
  *
  *
  */
+import java.awt.BorderLayout;
 
+import javax.swing.JScrollPane;
+
+import org.protege.editor.owl.ui.frame.SWRLRulesFrame;
+import org.protege.editor.owl.ui.frame.SortedSWRLRulesFrame;
+import org.protege.editor.owl.ui.framelist.OWLFrameList;
+import org.semanticweb.owlapi.model.OWLOntology;
 
 /**
  * Author: Matthew Horridge<br>
  * The University Of Manchester<br>
  * Bio-Health Informatics Group<br>
- * Date: 06-Jul-2007<br><br>
+ * Date: 06-Jul-2007<br>
+ * <br>
  */
 public class SWRLRulesViewComponent extends AbstractActiveOntologyViewComponent {
 
-    /**
-     * 
-     */
-    private static final long serialVersionUID = -204496848858955147L;
+	// TODO until we know how to call updateView properly
+	public static SWRLRulesViewComponent instance;
 
-    private OWLFrameList list;
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -204496848858955147L;
 
-    private SWRLRulesFrame frame;
+	private OWLFrameList list;
 
+	private SWRLRulesFrame frame;
 
-    protected void initialiseOntologyView() throws Exception {
-        frame = new SWRLRulesFrame(getOWLEditorKit());
-        list = new OWLFrameList(getOWLEditorKit(), frame);
-        setLayout(new BorderLayout());
-        add(new JScrollPane(list));
-        updateView(getOWLEditorKit().getModelManager().getActiveOntology());
-    }
+	public SWRLRulesViewComponent() {
+		instance = this;
+	}
 
+	protected void initialiseOntologyView() throws Exception {
+		frame = new SortedSWRLRulesFrame(getOWLEditorKit());
+		list = new OWLFrameList(getOWLEditorKit(), frame, false, true);
 
-    protected void disposeOntologyView() {
-        list.dispose();
-    }
+		setLayout(new BorderLayout());
+		add(new JScrollPane(list));
+		updateView(getOWLEditorKit().getModelManager().getActiveOntology());
+	}
 
+	protected void disposeOntologyView() {
+		list.dispose();
 
-    protected void updateView(OWLOntology activeOntology) throws Exception {
-        list.setRootObject(activeOntology);
-    }
+		instance = null;
+	}
+
+	// TODO see above
+	public static void preferencesUpdated() {
+		if (instance != null)
+			try {
+				instance.updateView(instance.getOWLEditorKit().getModelManager().getActiveOntology());
+
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+	}
+
+	protected void updateView(OWLOntology activeOntology) throws Exception {
+		list.setRootObject(activeOntology);
+	}
 }

--- a/protege-editor-owl/src/main/resources/plugin.xml
+++ b/protege-editor-owl/src/main/resources/plugin.xml
@@ -1597,6 +1597,12 @@
         <class value="org.protege.editor.owl.ui.explanation.ExplanationPreferencesGeneralPanel"/>
     </extension>
 
+    <extension id="ui.swrl.prefs"
+               point="org.protege.editor.core.application.preferencespanel">
+        <label value="SWRL Rules"/>
+        <class value="org.protege.editor.owl.ui.preferences.SWRLRulePreferencesPanel"/>
+    </extension>
+
     <!-- Move axioms kits -->
 
     <extension id="MoveAxiomsByReference"


### PR DESCRIPTION
This PR pertains to [my old post](https://github.com/protegeproject/protege/issues/802) on **sorting rules** (i.e., the rules that appear for Window > Views > Ontology views > Rules). I had a project where I had to create large amounts of rules and this feature helped me greatly. I finally found some time to share this extension.

It adds the possibility (see Preferences menu) to show _rdfs:comment_ annotations for rules, and sort them on these annotations. 

There is still an issue remaining though: to have an _already displayed rules view_ updated when changing the preferences, I manually had to call the `updateView `method on `SWRLRulesViewComponent`. I'm unsure how to implement this functionality properly .. 