### PR TITLE
Fix caching for #723

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
@@ -490,7 +490,7 @@ public class OWLCellRenderer implements TableCellRenderer, TreeCellRenderer, Lis
         }
         if (component instanceof LinkedObjectComponent && OWLRendererPreferences.getInstance().isRenderHyperlinks()) {
             linkedObjectComponent = (LinkedObjectComponent) component;
-            Point mouseLoc = component.getMousePosition(true);
+            Point mouseLoc = component.getMousePosition();
             if (mouseLoc == null) {
                 linkedObjectComponent.setLinkedObject(null);
                 return;


### PR DESCRIPTION
in MList the method getMousePosition() was cached, but OWLCellRenderer
calls getMousePosition(boolean) that was not cached

I changed the method in OWLCellRenderer to getMousePosition() and everything now flies ;-)
I am not sure why the boolean flag is needed, but I guess it is possible also to cache the other method call as well.