### PR TITLE
fix typo in warnUserIfReasonerIsNotConfigured

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/inference/ReasonerUtilities.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/inference/ReasonerUtilities.java
@@ -47,7 +47,7 @@ public class ReasonerUtilities {
             break;
 		case INITIALIZATION_IN_PROGRESS:
             JOptionPane.showMessageDialog(owner,
-                    "Reasoner still intializing.  Wait for initialization to complete.",
+                    "Reasoner still initializing.  Wait for initialization to complete.",
                     "Reasoner initializing",
                     JOptionPane.WARNING_MESSAGE);
             break;


### PR DESCRIPTION
Also, I noticed in the case NO_REASONER_FACTORY_CHOSEN it says "the Reasoner menu" but in the REASONER_NOT_INITIALIZED case it is "the reasoner menu". I guess it should have the same capitalization?