### PR TITLE
Remove unused dependency

### DIFF
--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -19,12 +19,6 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>edu.stanford.protege</groupId>
-			<artifactId>protege-launcher</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.googlecode.mdock</groupId>
 			<artifactId>mdock</artifactId>
 			<scope>provided</scope>


### PR DESCRIPTION
Dependency towards `protege-launcher` is declared in the `pom` of module `protege-editor-core`. However, this dependency is not used in this project, which causes an unnecessarily complex dependency tree for the module. The dependency can be removed safely. 