### PR TITLE
Fixes #767

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/editor/OWLConstantEditor.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/editor/OWLConstantEditor.java
@@ -128,9 +128,11 @@ public class OWLConstantEditor extends JPanel implements OWLObjectEditor<OWLLite
             langTagField.clear();
         }
         else if(isLangSelected()) {
-            datatypeField.setSelectedItem(null);
+            datatypeField.setSelectedItem(OWL2Datatype.RDF_PLAIN_LITERAL.getDatatype(this.dataFactory));
+            datatypeField.setEnabled(false);
         }
         else {
+            datatypeField.setEnabled(true);
             OWLDatatype selDatatype = (OWLDatatype) datatypeField.getSelectedItem();
             if(isBuiltInParseableDatatpe(selDatatype) || selDatatype == null) {
                 OWLLiteralParser parser = new OWLLiteralParser(dataFactory);


### PR DESCRIPTION
Set a default datatype rdf:plainLiteral when a language tag is selected. The data type dropdown is disabled as long as a language tag is selected.
I have attached screenshots for the same.

![Screenshot (40)](https://user-images.githubusercontent.com/32883387/83337015-8c12d680-a2d5-11ea-8beb-1a0eba13931c.png)
