### PR TITLE
Save files using format-specific extensions.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/OWLEditorKit.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/OWLEditorKit.java
@@ -18,6 +18,7 @@ import org.protege.editor.owl.model.io.IOListenerPluginLoader;
 import org.protege.editor.owl.model.search.SearchManager;
 import org.protege.editor.owl.model.search.SearchManagerSelector;
 import org.protege.editor.owl.ui.OntologyFormatPanel;
+import org.protege.editor.owl.ui.Extensions;
 import org.protege.editor.owl.ui.UIHelper;
 import org.protege.editor.owl.ui.error.OntologyLoadErrorHandlerUI;
 import org.protege.editor.owl.ui.explanation.ExplanationManager;
@@ -364,7 +365,7 @@ public class OWLEditorKit extends AbstractEditorKit<OWLEditorKitFactory> {
                 }
             }
         }
-        File file = getSaveAsOWLFile(ont);
+        File file = getSaveAsOWLFile(ont, format.get());
         if (file != null) {
             man.setOntologyFormat(ont, format.get());
             man.setOntologyDocumentIRI(ont, IRI.create(file));
@@ -378,16 +379,18 @@ public class OWLEditorKit extends AbstractEditorKit<OWLEditorKitFactory> {
     }
 
 
-    private File getSaveAsOWLFile(@Nonnull OWLOntology ont) {
+    private File getSaveAsOWLFile(@Nonnull OWLOntology ont, @Nonnull OWLDocumentFormat fmt) {
         UIHelper helper = new UIHelper(this);
-        File file = helper.saveOWLFile(String.format("Please select a location in which to save: %s", getModelManager().getRendering(ont)));
+        List<String> extensions = Extensions.getExtensions(fmt);
+        File file = helper.saveOWLFile(String.format("Please select a location in which to save: %s", getModelManager().getRendering(ont)),
+                                       new HashSet<>(extensions));
         if (file != null) {
             int extensionIndex = file.toString().lastIndexOf('.');
             if (extensionIndex == -1) {
-                file = new File(file.toString() + ".owl");
+                file = new File(file.toString() + extensions.get(0));
             }
-            else if (extensionIndex != file.toString().length() - 4) {
-                file = new File(file.toString() + ".owl");
+            else if (! extensions.contains(file.toString().substring(extensionIndex))) {
+                file = new File(file.toString() + extensions.get(0));
             }
         }
         return file;

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/Extensions.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/Extensions.java
@@ -1,0 +1,68 @@
+package org.protege.editor.owl.ui;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.semanticweb.owlapi.formats.*;
+import org.semanticweb.owlapi.model.OWLDocumentFormat;
+
+
+/**
+ * Author: Damien Goutte-Gattat<br>
+ * University of Cambridge<br>
+ * FlyBase Group<br>
+ * Date: Jul 24, 2021<br><br>
+
+ * dpg44@cam.ac.uk<br><br>
+ */
+public class Extensions {
+    private final static HashMap<OWLDocumentFormat, List<String>> format_extensions;
+
+    static {
+        format_extensions = new HashMap<OWLDocumentFormat, List<String>>();
+
+        format_extensions.put(new RDFXMLDocumentFormat(),
+                            Arrays.asList(".rdf", ".xml"));
+        format_extensions.put(new TurtleDocumentFormat(),
+                            Arrays.asList(".ttl", ".turtle"));
+        format_extensions.put(new OWLXMLDocumentFormat(),
+                            Arrays.asList(".owx", ".xml", ".owl"));
+        format_extensions.put(new FunctionalSyntaxDocumentFormat(),
+                            Arrays.asList(".ofn"));
+        format_extensions.put(new ManchesterSyntaxDocumentFormat(),
+                            Arrays.asList(".omn"));
+        format_extensions.put(new OBODocumentFormat(),
+                            Arrays.asList(".obo"));
+        format_extensions.put(new LatexDocumentFormat(),
+                            Arrays.asList(".tex"));
+        format_extensions.put(new RDFJsonLDDocumentFormat(),
+                            Arrays.asList(".jsonld"));
+        format_extensions.put(new NTriplesDocumentFormat(),
+                            Arrays.asList(".n3", ".nt"));
+    }
+
+    public static List<String> getExtensions(OWLDocumentFormat fmt) {
+        if (format_extensions.containsKey(fmt)) {
+            return format_extensions.get(fmt);
+        }
+        else {
+            return Arrays.asList(".owl");
+        }
+    }
+
+    public static List<String> getExtensions() {
+        List<String> extensions = new ArrayList<>();
+
+        for (List<String> exts : format_extensions.values()) {
+            for (String ext : exts) {
+                if (! extensions.contains(ext)) {
+                    extensions.add(ext);
+                }
+            }
+        }
+
+        return extensions;
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/UIHelper.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/UIHelper.java
@@ -39,22 +39,7 @@ public class UIHelper {
 
     private OWLEditorKit owlEditorKit;
 
-    public final static Set<String> OWL_EXTENSIONS;
-    static {
-    	Set<String> extensions = new HashSet<>();
-        extensions.add("owl");
-        extensions.add("ofn");
-        extensions.add("omn");
-        extensions.add("owx");
-        extensions.add("rdf");
-        extensions.add("xml");
-        extensions.add("obo");
-        extensions.add("n3");
-        extensions.add("ttl");
-        extensions.add("turtle");
-        extensions.add("pom");
-        OWL_EXTENSIONS = Collections.unmodifiableSet(extensions);
-    }
+    public final static Set<String> OWL_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Extensions.getExtensions()));
 
 
     public UIHelper(OWLEditorKit owlEditorKit) {
@@ -272,10 +257,15 @@ public class UIHelper {
 
 
     public File saveOWLFile(String title) {
+        return saveOWLFile(title, OWL_EXTENSIONS);
+    }
+
+
+    public File saveOWLFile(String title, Set<String> extensions) {
         return UIUtil.saveFile((JFrame) SwingUtilities.getAncestorOfClass(JFrame.class, getParent()),
                                title,
-                               "OWL File", 
-                               OWL_EXTENSIONS);
+                               "OWL File",
+                               extensions);
     }
 
 


### PR DESCRIPTION
This PR makes Protégé save a new ontology in a file with an extension suitable to the format chosen by the user, instead of systematically using a ".owl" extension regardless of the format.

It attempts to centralise the association between a format and its extensions in a new static `Extensions` class, which can then be used both when saving a new file (to only allow extensions matching the intended save format) and when opening a file (to allow all extensions for all supported formats).

Related to #969, #1012, and #1015.