### PR TITLE
`.nt` as preferred extension for N-Triples

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/Extensions.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/Extensions.java
@@ -40,7 +40,7 @@ public class Extensions {
         format_extensions.put(new RDFJsonLDDocumentFormat(),
                             Arrays.asList(".jsonld"));
         format_extensions.put(new NTriplesDocumentFormat(),
-                            Arrays.asList(".n3", ".nt"));
+                            Arrays.asList(".nt", ".n3" /** .n3 is not an official N-Triples extension, but easy to confuse **/));
     }
 
     public static List<String> getExtensions(OWLDocumentFormat fmt) {


### PR DESCRIPTION
`.nt` should be the preferred [extension of N-Triples](https://www.w3.org/TR/n-triples/#h2_sec-mediaReg-n-triples). `.n3` is the [extension for Notation3](https://www.w3.org/TeamSubmission/n3/). `.n3` is kept as second choice, as it might in practice be used by mistake for N-Triple files.