### PR TITLE
Could edu.stanford.protege:protege-launcher:5.6.0-beta-1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/protege-launcher/pom.xml
+++ b/protege-launcher/pom.xml
@@ -20,6 +20,20 @@
 		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
 			<artifactId>owlapi-osgidistribution</artifactId>
+			<exclusions>
+				<exclusion>
+				    <groupId>com.google.errorprone</groupId>
+				    <artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.servicemix.bundles</groupId>
+				    <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.google.code.findbugs</groupId>
+				    <artifactId>jsr305</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -48,18 +62,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jul-to-slf4j</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-		</dependency>
-		
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
 		</dependency>
 
 		<dependency>
@@ -75,11 +79,6 @@
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>
 			<artifactId>org.apache.servicemix.bundles.aopalliance</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.servicemix.bundles</groupId>
-			<artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_edu.stanford.protege:protege-launcher:5.6.0-beta-1-SNAPSHOT_** introduced **_60_** dependencies. However, among them, **_4_** libraries (**_6%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-inject:jar:1_2:compile
com.google.errorprone:error_prone_annotations:jar:2.4.0:compile
com.google.code.findbugs:jsr305:jar:3.0.1:compile
org.slf4j:jul-to-slf4j:jar:1.7.12:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, 2 of the redundant dependencies **_org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-inject:jar:1_2:compile, com.google.code.findbugs:jsr305:jar:3.0.1:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_edu.stanford.protege:protege-launcher:5.6.0-beta-1-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_edu.stanford.protege:protege-launcher:5.6.0-beta-1-SNAPSHOT_**’s maven tests.

Best regards