### PR TITLE
Use HTTPS for ORCiD

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/user/Orcid.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/user/Orcid.java
@@ -16,7 +16,7 @@ public class Orcid {
 
     private static final Pattern PATTERN = Pattern.compile("[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]");
 
-    public static final String ORCID_URI_PREFIX = "http://orcid.org/";
+    public static final String ORCID_URI_PREFIX = "https://orcid.org/";
 
     private final String value;
 

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/Orcid_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/Orcid_TestCase.java
@@ -65,7 +65,7 @@ public class Orcid_TestCase {
     }
 
     public void shouldGetUri() {
-        assertThat(orcid.toUri(), is(URI.create("http://orcid.org/" + value)));
+        assertThat(orcid.toUri(), is(URI.create("https://orcid.org/" + value)));
     }
 
 }


### PR DESCRIPTION
Closes #1045
CC @matentzn

ORCiD's standard is to use HTTPS, this PR updates the construction of URIs to reflect this.