### PR TITLE
Fixed failing test case for OboFoundryRegistryParser

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/obofoundry/OboFoundryRegistryParser.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/obofoundry/OboFoundryRegistryParser.java
@@ -18,7 +18,7 @@ import java.net.URL;
  */
 public class OboFoundryRegistryParser {
 
-    private static final URI OBO_FOUNDRY_REGISTRY_LOCATION = URI.create("http://www.obofoundry.org/registry/ontologies.jsonld");
+    private static final URI OBO_FOUNDRY_REGISTRY_LOCATION = URI.create("https://obofoundry.org/registry/ontologies.jsonld");
 
     @Nonnull
     public static URI getStandardRegistryLocation() {


### PR DESCRIPTION
The test case `OboFoundryRegistryParser_IT.shouldParseRegistryFromStandardLocation()` fails for me when compiling on Mac OS 12. The reason is that the URL `http://www.obofoundry.org/registry/ontologies.jsonld` returns an HTTP page with status code 301 "Moved Permanently", which points to `https://obofoundry.org/registry/ontologies.jsonld`, but the `InputStream` is not automatically redirected. The `OboFoundryRegistryParser` then tries to parse this HTTP page and fails.

This pull request fixes this by changing the URL for the OBO Foundry registry in `OboFoundryRegistryParser`.