### PR TITLE
Sorting and disabling functionality for ExplanationServices

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationDialog.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationDialog.java
@@ -1,21 +1,12 @@
 package org.protege.editor.owl.ui.explanation;
 
-import org.protege.editor.core.prefs.Preferences;
-import org.protege.editor.core.prefs.PreferencesManager;
-import org.protege.editor.owl.model.inference.ReasonerPreferences;
 import org.semanticweb.owlapi.model.OWLAxiom;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.Collection;
 
 public class ExplanationDialog extends JPanel {
-
-    public static final String PREFERENCES_SET_KEY = "EXPLANATION_PREFS_SET";
-
-    public static final String DEFAULT_EXPLANATION_ID = "PREFERRED_PLUGIN_ID";
 
     private JPanel explanationContainer;
 
@@ -46,22 +37,27 @@ public class ExplanationDialog extends JPanel {
     private JComboBox<ExplanationService> createComboBox(Collection<ExplanationService> explanationServices) {
         ExplanationService[] teacherArray = explanationServices.toArray(new ExplanationService[explanationServices.size()]);
         final JComboBox<ExplanationService> selector = new JComboBox<>(teacherArray);
+		final ExplanationPreferences prefs = ExplanationPreferences.create().load();
         if (teacherArray.length > 0) {
             ExplanationService selected = teacherArray[0];
-            String id = getDefaultPluginId();
-            if (id != null) {
-                for (ExplanationService t : explanationServices) {
-                    if (id.equals(t.getPluginId())) {
-                        selected = t;
-                    }
-                }
-            }
+			if (prefs.useLastExplanationService) {
+				String id = prefs.defaultExplanationService;
+				if (id != null) {
+					for (ExplanationService t : explanationServices) {
+						if (id.equals(t.getPluginId())) {
+							selected = t;
+						}
+					}
+				}
+			}
             selector.setSelectedItem(selected);
             explanation = selected.explain(axiom);
         }
         selector.addActionListener(e -> {
             ExplanationService t = (ExplanationService) selector.getSelectedItem();
-            setDefaultPluginId(t.getPluginId());
+			prefs.load();
+			prefs.defaultExplanationService = t.getPluginId();
+			prefs.save();
             explanationContainer.removeAll();
             if (explanation != null) {
                 explanation.dispose();
@@ -71,19 +67,6 @@ public class ExplanationDialog extends JPanel {
             revalidate();
         });
         return selector;
-    }
-
-
-    public String getDefaultPluginId() {
-        PreferencesManager prefMan = PreferencesManager.getInstance();
-        Preferences prefs = prefMan.getPreferencesForSet(PREFERENCES_SET_KEY, ReasonerPreferences.class);
-        return prefs.getString(DEFAULT_EXPLANATION_ID, null);
-    }
-
-    public void setDefaultPluginId(String id) {
-        PreferencesManager prefMan = PreferencesManager.getInstance();
-        Preferences prefs = prefMan.getPreferencesForSet(PREFERENCES_SET_KEY, ReasonerPreferences.class);
-        prefs.putString(DEFAULT_EXPLANATION_ID, id);
     }
 
     public void dispose() {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationManager.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationManager.java
@@ -5,9 +5,12 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
@@ -26,8 +29,10 @@ public class ExplanationManager implements Disposable {
 
 	private final OWLEditorKit editorKit;
 
-	private final Collection<ExplanationService> explanationServices = new HashSet<>();
-	
+	private final Collection<ExplanationService> explanationServices = new ArrayList<>();
+
+	private final Collection<ExplanationService> enabledServices = new ArrayList<>();
+
 	private final Collection<ExplanationDialog> openedExplanations = new HashSet<>();
 	
 	public ExplanationManager(OWLEditorKit editorKit) {
@@ -37,16 +42,50 @@ public class ExplanationManager implements Disposable {
 
 	public void reload() {
 		ExplanationPluginLoader loader = new ExplanationPluginLoader(editorKit);
-		explanationServices.clear();
+		// use TreeMap for alphabetical ordering
+		Map<String, ExplanationService> sortedExplanationServices = new TreeMap<>();
 		for (ExplanationPlugin plugin : loader.getPlugins()) {
 			ExplanationService teacher = null;
 			try {
 				teacher = plugin.newInstance();
 				teacher.initialise();
+				sortedExplanationServices.put(teacher.getPluginId(), teacher);
+			} catch (Exception e) {
+				logger.error("An error occurred whilst initialising an explanation service {}.", plugin.getName(), e);
+			}
+		}
+
+		// add ExplanationServices in the order defined in the preferences
+		final ExplanationPreferences prefs = ExplanationPreferences.create().load();
+		explanationServices.clear();
+		for (String id : prefs.explanationServicesList) {
+			ExplanationService teacher = sortedExplanationServices.get(id);
+			if (teacher != null) {
+				explanationServices.add(teacher);
+				sortedExplanationServices.remove(id);
+			}
+		}
+
+		if (!sortedExplanationServices.isEmpty()) {
+			// add new ExplanationServices (which do not occur in the preferences yet) in
+			// alphabetical order at the end
+			for (ExplanationService teacher : sortedExplanationServices.values()) {
 				explanationServices.add(teacher);
 			}
-			catch (Exception e) {
-				logger.error("An error occurred whilst initialising an explanation service {}.", plugin.getName(), e);
+		}
+
+		// update preferences according to current list (adding new and removing old
+		// ExplanationServices)
+		prefs.explanationServicesList = new ArrayList<>();
+		for (ExplanationService teacher : explanationServices) {
+			prefs.explanationServicesList.add(teacher.getPluginId());
+		}
+		prefs.save();
+
+		enabledServices.clear();
+		for (ExplanationService teacher : explanationServices) {
+			if (!prefs.disabledExplanationServices.contains(teacher.getPluginId())) {
+				enabledServices.add(teacher);
 			}
 		}
 	}
@@ -64,8 +103,8 @@ public class ExplanationManager implements Disposable {
 	}
 	
 	public Collection<ExplanationService> getTeachers(OWLAxiom axiom) {
-		Set<ExplanationService> smartTeachers = new HashSet<>();
-		for (ExplanationService teacher : explanationServices) {
+		Collection<ExplanationService> smartTeachers = new ArrayList<>();
+		for (ExplanationService teacher : enabledServices) {
 			if (teacher.hasExplanation(axiom)) {
 				smartTeachers.add(teacher);
 			}
@@ -74,7 +113,7 @@ public class ExplanationManager implements Disposable {
 	}
 	
 	public boolean hasExplanation(OWLAxiom axiom) {
-		for (ExplanationService explanationService : explanationServices) {
+		for (ExplanationService explanationService : enabledServices) {
 			if (explanationService.hasExplanation(axiom)) {
 				return true;
 			}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationPreferences.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationPreferences.java
@@ -1,0 +1,69 @@
+package org.protege.editor.owl.ui.explanation;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.protege.editor.core.prefs.Preferences;
+import org.protege.editor.core.prefs.PreferencesManager;
+
+public class ExplanationPreferences {
+
+	private static final String PREFERENCES_SET_KEY_ = "EXPLANATION_PREFS_SET",
+			DEFAULT_EXPLANATION_ID_ = "PREFERRED_PLUGIN_ID",
+			USE_LAST_EXPLANATION_SERVICE_KEY_ = "USE_LAST_EXPLANATION_SERVICE",
+			EXPLANATION_SERVICES_LIST_KEY_ = "EXPLANATION_SERVICES_LIST",
+			DISABLED_EXPLANATION_SERVICES_KEY_ = "DISABLED_EXPLANATION_SERVICES";
+
+	private final static String DEFAULT_DEFAULT_EXPLANATION_ID_ = null;
+	private final static boolean DEFAULT_USE_LAST_EXPLANATION_SERVICE_ = true;
+	private final static List<String> DEFAULT_EXPLANATION_SERVICES_LIST_ = Collections.emptyList();
+	private final static List<String> DEFAULT_DISABLED_EXPLANATION_SERVICES_ = Collections.emptyList();
+
+	public String defaultExplanationService;
+	public boolean useLastExplanationService;
+	public List<String> explanationServicesList;
+	public List<String> disabledExplanationServices;
+
+	private ExplanationPreferences() {
+		// use create()
+	}
+
+	public static ExplanationPreferences create() {
+		return new ExplanationPreferences().reset();
+	}
+
+	private static Preferences getPrefs() {
+		PreferencesManager prefMan = PreferencesManager.getInstance();
+		return prefMan.getPreferencesForSet(PREFERENCES_SET_KEY_, ExplanationPreferences.class);
+	}
+
+	public ExplanationPreferences load() {
+		Preferences prefs = getPrefs();
+		defaultExplanationService = prefs.getString(DEFAULT_EXPLANATION_ID_, DEFAULT_DEFAULT_EXPLANATION_ID_);
+		useLastExplanationService = prefs.getBoolean(USE_LAST_EXPLANATION_SERVICE_KEY_,
+				DEFAULT_USE_LAST_EXPLANATION_SERVICE_);
+		explanationServicesList = prefs.getStringList(EXPLANATION_SERVICES_LIST_KEY_,
+				DEFAULT_EXPLANATION_SERVICES_LIST_);
+		disabledExplanationServices = prefs.getStringList(DISABLED_EXPLANATION_SERVICES_KEY_,
+				DEFAULT_DISABLED_EXPLANATION_SERVICES_);
+		return this;
+	}
+
+	public ExplanationPreferences save() {
+		Preferences prefs = getPrefs();
+		prefs.putString(DEFAULT_EXPLANATION_ID_, defaultExplanationService);
+		prefs.putBoolean(USE_LAST_EXPLANATION_SERVICE_KEY_, useLastExplanationService);
+		prefs.putStringList(EXPLANATION_SERVICES_LIST_KEY_, explanationServicesList);
+		prefs.putStringList(DISABLED_EXPLANATION_SERVICES_KEY_, disabledExplanationServices);
+		return this;
+	}
+
+	public ExplanationPreferences reset() {
+		defaultExplanationService = DEFAULT_DEFAULT_EXPLANATION_ID_;
+		useLastExplanationService = DEFAULT_USE_LAST_EXPLANATION_SERVICE_;
+		explanationServicesList = DEFAULT_EXPLANATION_SERVICES_LIST_;
+		disabledExplanationServices = DEFAULT_DISABLED_EXPLANATION_SERVICES_;
+		return this;
+	}
+
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationPreferencesGeneralPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/ExplanationPreferencesGeneralPanel.java
@@ -3,10 +3,16 @@ package org.protege.editor.owl.ui.explanation;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
-import javax.swing.DefaultListModel;
-import javax.swing.JList;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
 
 import org.protege.editor.core.ui.preferences.PreferencesLayoutPanel;
 import org.protege.editor.owl.ui.preferences.OWLPreferencesPanel;
@@ -15,30 +21,123 @@ public class ExplanationPreferencesGeneralPanel extends OWLPreferencesPanel {
 
 	private static final long serialVersionUID = -3354987384223578780L;
 
+	private JRadioButton buttonLast, buttonFirst;
+	private SortedPluginsTableModel tableModel;
+
 	@Override
-    public void initialise() throws Exception {
-        setLayout(new BorderLayout());
-        PreferencesLayoutPanel panel = new PreferencesLayoutPanel();
-        add(panel, BorderLayout.NORTH);
+	public void initialise() throws Exception {
+		setLayout(new BorderLayout());
+		PreferencesLayoutPanel panel = new PreferencesLayoutPanel();
+		add(panel, BorderLayout.NORTH);
+		addDefaultExplanationServiceComponent(panel);
+		addInstalledExplanationServicesComponent(panel);
+		loadFrom(ExplanationPreferences.create().load());
+	}
 
-        panel.addGroup("Installed explanation services");
-        DefaultListModel<String> pluginModel = new DefaultListModel<>();
-        ExplanationManager manager = new ExplanationManager(getOWLEditorKit());
-        Collection<ExplanationService> services = manager.getExplainers();
-        for (ExplanationService service : services)
-            pluginModel.addElement(service.getName());
-        JList<String> pluginList = new JList<>(pluginModel);
-        pluginList.setToolTipText("Plugins that provide explanation facilities");
-        JScrollPane pluginInfoScrollPane = new JScrollPane(pluginList);
-        pluginInfoScrollPane.setPreferredSize(new Dimension(300, 100));
-        panel.addGroupComponent(pluginInfoScrollPane);
-    }
+	@Override
+	public void dispose() throws Exception {
+	}
 
-    @Override
-    public void dispose() throws Exception {
-    }
+	@Override
+	public void applyChanges() {
+		ExplanationPreferences prefs = ExplanationPreferences.create();
+		saveTo(prefs);
+		prefs.save();
+		getOWLEditorKit().getModelManager().getExplanationManager().reload();
+	}
 
-    @Override
-    public void applyChanges() {
-    }
+	private void loadFrom(ExplanationPreferences prefs) {
+		if (prefs.useLastExplanationService) {
+			buttonLast.setSelected(true);
+		} else {
+			buttonFirst.setSelected(true);
+		}
+		tableModel.setPluginIds(prefs.explanationServicesList);
+		tableModel.setDisabledIds(prefs.disabledExplanationServices);
+	}
+
+	private void saveTo(ExplanationPreferences prefs) {
+		prefs.useLastExplanationService = buttonLast.isSelected();
+		prefs.explanationServicesList = tableModel.getPluginIds();
+		prefs.disabledExplanationServices = tableModel.getDisabledIds();
+	}
+
+	private void addDefaultExplanationServiceComponent(PreferencesLayoutPanel panel) {
+		panel.addGroup("Default explanation service");
+		buttonLast = new JRadioButton("Most recently used explanation service");
+		buttonLast.setToolTipText(
+				"Always use the most recently used explanation service, if it can provide an explanation for the chosen axiom");
+		buttonFirst = new JRadioButton("First available explanation service from the list below");
+		buttonFirst.setToolTipText(
+				"Always use the first explanation service from the list below that can provide an explanation for the chosen axiom");
+		ButtonGroup group = new ButtonGroup();
+		group.add(buttonLast);
+		group.add(buttonFirst);
+		panel.addGroupComponent(buttonLast);
+		panel.addGroupComponent(buttonFirst);
+	}
+
+	private void addInstalledExplanationServicesComponent(PreferencesLayoutPanel panel) {
+		panel.addGroup("Installed explanation services");
+		Collection<ExplanationService> services = getOWLEditorKit().getOWLModelManager().getExplanationManager()
+				.getExplainers();
+		Map<String, String> nameMap = new HashMap<>();
+		for (ExplanationService service : services) {
+			nameMap.put(service.getPluginId(), service.getName());
+		}
+		tableModel = new SortedPluginsTableModel(nameMap);
+		JTable pluginTable = new JTable(tableModel);
+		pluginTable.setToolTipText(
+				"Plugins that provide explanation facilities. You can disable and enable plugins and change their order using the buttons below.");
+		pluginTable.setRowSelectionAllowed(true);
+		pluginTable.setColumnSelectionAllowed(false);
+		pluginTable.getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		pluginTable.getColumnModel().getColumn(0).setMaxWidth(20);
+		pluginTable.getColumnModel().getColumn(1).setMaxWidth(50);
+		pluginTable.getColumnModel().getColumn(2).setMinWidth(300);
+		pluginTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+		JScrollPane pluginTableScrollPane = new JScrollPane(pluginTable);
+		pluginTableScrollPane.setPreferredSize(new Dimension(400, 100));
+		panel.addGroupComponent(pluginTableScrollPane);
+		addUpDownButtons(panel, pluginTable);
+	}
+
+	private void addUpDownButtons(PreferencesLayoutPanel panel, JTable pluginTable) {
+		JButton buttonUp = new JButton("↑ Move up");
+		buttonUp.setToolTipText("Move the selected explanation service towards the top of the list");
+		buttonUp.addActionListener(e -> {
+			int rowIndex = pluginTable.getSelectedRow();
+			if (rowIndex > 0) {
+				tableModel.swap(rowIndex - 1, rowIndex);
+			}
+			pluginTable.setRowSelectionInterval(rowIndex - 1, rowIndex - 1);
+		});
+
+		JButton buttonDown = new JButton("↓ Move down︎");
+		buttonDown.setToolTipText("Move the selected explanation service towards the bottom of the list");
+		buttonDown.addActionListener(e -> {
+			int rowIndex = pluginTable.getSelectedRow();
+			if (rowIndex < pluginTable.getRowCount() - 1) {
+				tableModel.swap(rowIndex, rowIndex + 1);
+			}
+			pluginTable.setRowSelectionInterval(rowIndex + 1, rowIndex + 1);
+		});
+
+		JPanel buttonsUpDown = new JPanel();
+		buttonsUpDown.add(buttonUp);
+		buttonsUpDown.add(buttonDown);
+		panel.addGroupComponent(buttonsUpDown);
+
+		pluginTable.getSelectionModel().addListSelectionListener(e -> {
+			int rowIndex = pluginTable.getSelectedRow();
+			if (rowIndex == -1) {
+				buttonUp.setEnabled(false);
+				buttonDown.setEnabled(false);
+			} else {
+				buttonUp.setEnabled(rowIndex > 0);
+				buttonDown.setEnabled(rowIndex < pluginTable.getRowCount() - 1);
+			}
+		});
+	}
+
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/SortedPluginsTableModel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/explanation/SortedPluginsTableModel.java
@@ -1,0 +1,103 @@
+package org.protege.editor.owl.ui.explanation;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.table.AbstractTableModel;
+
+public class SortedPluginsTableModel extends AbstractTableModel {
+
+	private List<String> pluginIds;
+	private List<String> disabledIds;
+	private Map<String, String> nameMap;
+
+	private String[] columnNames = new String[] { "#", "Enabled", "Plugin" };
+	private Class<?>[] columnClasses = new Class<?>[] { Integer.class, Boolean.class, String.class };
+
+	public SortedPluginsTableModel(Map<String, String> nameMap) {
+		this.nameMap = nameMap;
+	}
+
+	public List<String> getPluginIds() {
+		return pluginIds;
+	}
+
+	public List<String> getDisabledIds() {
+		return disabledIds;
+	}
+
+	public void setPluginIds(List<String> pluginIds) {
+		this.pluginIds = pluginIds;
+		fireTableDataChanged();
+	}
+
+	public void setDisabledIds(List<String> disabledIds) {
+		this.disabledIds = disabledIds;
+		fireTableDataChanged();
+	}
+
+	@Override
+	public int getRowCount() {
+		return pluginIds.size();
+	}
+
+	@Override
+	public int getColumnCount() {
+		return 3;
+	}
+
+	@Override
+	public String getColumnName(int columnIndex) {
+		return columnNames[columnIndex];
+	}
+
+	@Override
+	public Class<?> getColumnClass(int columnIndex) {
+		return columnClasses[columnIndex];
+	}
+
+	@Override
+	public boolean isCellEditable(int rowIndex, int columnIndex) {
+		return columnIndex == 1;
+	}
+
+	@Override
+	public Object getValueAt(int rowIndex, int columnIndex) {
+		String pluginId = pluginIds.get(rowIndex);
+		switch (columnIndex) {
+		case 0:
+			return rowIndex + 1;
+		case 1:
+			return !disabledIds.contains(pluginId);
+		case 2:
+			return nameMap.get(pluginId);
+		default:
+			throw new IllegalArgumentException("Invalid column index: " + columnIndex);
+		}
+	}
+
+	@Override
+	public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+		assert (columnIndex == 1);
+		boolean enabled = (Boolean) aValue;
+		String pluginId = pluginIds.get(rowIndex);
+		if (enabled) {
+			disabledIds.remove(pluginId);
+		} else {
+			if (!disabledIds.contains(pluginId)) {
+				disabledIds.add(pluginId);
+			}
+		}
+		fireTableCellUpdated(rowIndex, columnIndex);
+	}
+
+	public void swap(int rowIndex1, int rowIndex2) {
+		String pluginId1 = pluginIds.get(rowIndex1);
+		String pluginId2 = pluginIds.get(rowIndex2);
+		pluginIds.set(rowIndex1, pluginId2);
+		pluginIds.set(rowIndex2, pluginId1);
+		fireTableRowsUpdated(rowIndex1, rowIndex1);
+		fireTableRowsUpdated(rowIndex2, rowIndex2);
+	}
+
+}


### PR DESCRIPTION
This pull request modifies the general Explanation preferences. Users can choose between (a) always using the most recently used explanation service when requesting a new explanation (current behavior and default) and (b) using the explanation services according to a user-defined order. Additionally, individual explanations services can be disabled in the preferences. The reason is that a user may always want to compute justifications first (because it may be faster), and only request more expensive explanations when the justifications aren't enough.

![Bildschirmfoto 2022-06-16 um 14 22 35](https://user-images.githubusercontent.com/8749392/174068850-3a3dde3a-dcde-4dab-a68e-5da905682eae.png)

This came out of a discussion on liveontologies/protege-proof-explanation#2, where this functionality would be useful for sorting and filtering many different _proof services_ (e.g., supplied by https://github.com/liveontologies/elk-reasoner or https://github.com/de-tu-dresden-inf-lat/evee). It makes sense if this functionality is not only implemented at the level of proof services, but also in general for all explanation services. The proof service preferences can then also use the configuration options (a/b) described above.

For now, I tested this with the two explanation services https://github.com/protegeproject/explanation-workbench and https://github.com/liveontologies/protege-proof-explanation, but a similar implementation was tested for 10+ proof services.