### PR TITLE
owlapi version upgraded to 4.5.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 			<dependency>
 				<groupId>net.sourceforge.owlapi</groupId>
 				<artifactId>owlapi-osgidistribution</artifactId>
-				<version>4.5.19</version>
+				<version>4.5.22</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Owlapi version upgraded from `4.5.19` to `4.5.22`:

- No build errors
- All unit tests passing
- 'maven clean package' is successful

Should we check anything else to ensure package is OK? @matentzn