### PR TITLE
Add mnemonics (hotkeys) to menu bar. Resolve #1068.

### DIFF
--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/menu/MenuBuilder.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/menu/MenuBuilder.java
@@ -124,6 +124,7 @@ public class MenuBuilder {
     private void buildCompositeMenu(MenuActionPlugin plugin, JComponent menuContainer, List<MenuActionPlugin> children) {
         // Add a JMenu
         JMenu menu = new JMenu(plugin.getName());
+        menu.setMnemonic(Character.toLowerCase(plugin.getName().charAt(0)));
         menuContainer.add(menu);
         MenuActionPlugin lastPlugin = null;
         for (MenuActionPlugin childPlugin : children) {
@@ -140,6 +141,7 @@ public class MenuBuilder {
     private void buildDynamicMenu(MenuActionPlugin plugin, JComponent menuContainer) {
         // Construct dynamic menu.  This is basically a menu, whose children are determined at runtime.
         final JMenu menu = new JMenu(plugin.getName());
+        menu.setMnemonic(Character.toLowerCase(plugin.getName().charAt(0)));
         menuContainer.add(menu);
         try {
             // The menu must be a dynamic action menu.
@@ -176,6 +178,7 @@ public class MenuBuilder {
     private void buildTopLevelMenu(MenuActionPlugin plugin, JComponent menuContainer) {
         // This is a top level menu.  It is probably a place holder, so add it.
         JMenu menu = new JMenu(plugin.getName());
+        menu.setMnemonic(Character.toLowerCase(plugin.getName().charAt(0)));
         menuContainer.add(menu);
     }
 


### PR DESCRIPTION
Use the first character of each menu item as a mnemonic. This allows for example to press <kbd>Alt</kbd>+<kbd>F</kbd> to enter the file menu. This does not add a workable mnemonic to the Reasoner menu, because the R is already taken by Refactor. According to <https://bugs.openjdk.org/browse/JDK-4515762> that should actually work since 2012, but even if one of them doesn't work it is still a large step up from having no mnemonic at all. A more generic approach would be to extend the plugin XML files with an extra "mnemonic" attribute and support that, but that would be a much larger change.
This also adds a few mnemonics to inner parent menus but I think that is a positive change anyways.