### PR TITLE
Restore tab-triggered auto-completion

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderImpl.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderImpl.java
@@ -47,7 +47,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
 
     private String stripAndEscapeRendering(String rendering) {
         String strippedRendering;
-        if(rendering.startsWith("'") && rendering.endsWith("'")) {
+        if(rendering.startsWith("'") && rendering.endsWith("'") && rendering.length() > 1) {
             strippedRendering = rendering.substring(1, rendering.length() - 1);
         }
         else {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/clsdescriptioneditor/OWLAutoCompleter.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/clsdescriptioneditor/OWLAutoCompleter.java
@@ -168,6 +168,10 @@ public class OWLAutoCompleter {
             // Show popup
             performAutoCompletion();
         }
+        else if (e.getKeyCode() == KeyEvent.VK_TAB) {
+            e.consume();
+            performAutoCompletion();
+        }
         else if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
             if (popupWindow.isVisible()) {
                 // Hide popup


### PR DESCRIPTION
This PR restores the possibility to trigger auto-completion by pressing the `TAB` key (discussed in #1072).

It also fixes an (unrelated) problem that was discovered while investigating the auto-completion issue: an `IndexOutOfBoundsException` that can be thrown when the user starts entering a single `'` in the class expression editor. The exception does not actually crash Protégé and does not prevent the user from continuing to use the class expression editor, but it should still be avoided nonetheless.