### PR TITLE
Allow to configure Java options

### DIFF
--- a/protege-desktop/src/main/env/linux/run.sh
+++ b/protege-desktop/src/main/env/linux/run.sh
@@ -8,13 +8,25 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 cd "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
+conf_file=
+if [ -f "$HOME/.protege/conf/jvm.conf" ]; then
+  conf_file="$HOME/.protege/conf/jvm.conf"
+elif [ -f conf/jvm.conf ]; then
+  conf_file=conf/jvm.conf
+fi
+
+EXTRA_JVM_OPTIONS=
+if [ -n "$conf_file" ]; then
+  EXTRA_JVM_OPTIONS=$(sed -n 's/^max_heap_size=/-Xmx/p; s/^min_heap_size=/-Xms/p; s/^stack_size=/-Xss/p; s/^append=//p;' "$conf_file" | tr '\n' ' ')
+fi
+
 jre/bin/java \
      -DentityExpansionLimit=100000000 \
      -Dlogback.configurationFile=conf/logback.xml \
      -Dfile.encoding=UTF-8 \
      ${conf.extra.args} \
      -classpath bundles/guava.jar:bundles/logback-classic.jar:bundles/logback-core.jar:bundles/slf4j-api.jar:bundles/glassfish-corba-orb.jar:bin/org.apache.felix.main.jar:bin/maven-artifact.jar:bin/protege-launcher.jar \
-     $CMD_OPTIONS org.protege.osgi.framework.Launcher $1
+     $CMD_OPTIONS $EXTRA_JVM_OPTIONS org.protege.osgi.framework.Launcher $1
 
 
 

--- a/protege-desktop/src/main/env/platform-independent/run.sh
+++ b/protege-desktop/src/main/env/platform-independent/run.sh
@@ -8,12 +8,24 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 cd "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
+conf_file=
+if [ -f "$HOME/.protege/conf/jvm.conf" ]; then
+  conf_file="$HOME/.protege/conf/jvm.conf"
+elif [ -f conf/jvm.conf ]; then
+  conf_file=conf/jvm.conf
+fi
+
+EXTRA_JVM_OPTIONS=
+if [ -n "$conf_file" ]; then
+  EXTRA_JVM_OPTIONS=$(sed -n 's/^max_heap_size=/-Xmx/p; s/^min_heap_size=/-Xms/p; s/^stack_size=/-Xss/p; s/^append=//p;' "$conf_file" | tr '\n' ' ')
+fi
+
 java -Dlogback.configurationFile=conf/logback.xml \
      -DentityExpansionLimit=100000000 \
      -Dfile.encoding=UTF-8 \
      ${conf.extra.args} \
      -classpath bundles/guava.jar:bundles/logback-classic.jar:bundles/logback-core.jar:bundles/slf4j-api.jar:bundles/glassfish-corba-orb.jar:bin/org.apache.felix.main.jar:bin/maven-artifact.jar:bin/protege-launcher.jar \
-     $CMD_OPTIONS org.protege.osgi.framework.Launcher $1
+     $CMD_OPTIONS $EXTRA_JVM_OPTIONS org.protege.osgi.framework.Launcher $1
 
 
 


### PR DESCRIPTION
For the Linux-specific and the platform-independent package (which both relies on a run.sh script to start Protégé), update the run.sh script so that it detects a conf/jvm.conf (either in $HOME/.protege or in the package itself) and applies Java options found in that file.

The configuration file is expected to contain 'key=value' lines. Accepted keys are:

* max_heap_size (java's -Xmx option)
* min_heap_size (java's -Xms option)
* stack_size (java's -Xss option)
* append (allow passing an arbitrary java option)

(For the macOS-specific package, parsing this file is taken care of by the launcher binary.)