### PR TITLE
Do not allow sub-string matching when recognizing OBO IDs.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/util/OboUtilities.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/util/OboUtilities.java
@@ -43,7 +43,7 @@ public class OboUtilities {
      * @return true if the value to be tested matches the OBO Id pattern.
      */
     public static boolean isOboId(@Nonnull String value) {
-        return OBO_ID_PATTERN.matcher(checkNotNull(value)).find();
+        return OBO_ID_PATTERN.matcher(checkNotNull(value)).matches();
     }
 
     /**


### PR DESCRIPTION
The `OboUtilities.isOboId` method in `org.protege.editor.owl.model.util` is currently using the `Pattern.find` method to check whether its argument is an OBO ID.

This is inappropriate as the `Pattern.find` method looks for a subsequence within the string, instead of attempting to match the full string. As a result, a bogus OBO ID such as "MONDO:0018299-obsoleted" will be incorrectly identified as a *valid* OBO ID because the `Pattern.find` method will simply stop matching at the first character that does not fit the pattern (the '-'), but will still report that it has find a match.

Here, we need to check that the entire string matches the OBO ID pattern, which is why this commit replaces the use of `Pattern.find` by `Pattern.match`, which does precisely that.

This is also what the `getOboLibraryIriFromOboId` method, in the same class, is doing. For consistency, `isOboId` should do the same, so that when `isOboId` returns true, the calling code can then invoke `getOboLibraryIriFromOboId` on the same string and be confident that the call would not throw a "Invalid OBO Id" RuntimeException.