### PR TITLE
Do not override user-provided extension.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/OWLEditorKit.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/OWLEditorKit.java
@@ -389,9 +389,6 @@ public class OWLEditorKit extends AbstractEditorKit<OWLEditorKitFactory> {
             if (extensionIndex == -1) {
                 file = new File(file.toString() + extensions.get(0));
             }
-            else if (! extensions.contains(file.toString().substring(extensionIndex))) {
-                file = new File(file.toString() + extensions.get(0));
-            }
         }
         return file;
     }


### PR DESCRIPTION
When saving a file under a user-provided name, we check the name for any extension. If there is no extension or if the extension is not one of the allowed extensions for the chosen file format, we forcibly append an allowed extension to the filename.

This commit updates this behaviour to append an extension only in the case where there is no extension. If the user-provided filename already has an extension, we keep it as it is even if we don't recognize the extension.

closes #1087.