### PR TITLE
Fallback to OS-independent file-saving dialog on macOS

### DIFF
--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/util/UIUtil.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/util/UIUtil.java
@@ -152,7 +152,15 @@ public class UIUtil {
             parentWindow = SwingUtilities.getWindowAncestor(parent);
         }
         if(OSUtils.isOSX() && parentWindow != null) {
-            return MacUIUtil.saveFile(parentWindow, title, extensions, initialName);
+            File f = MacUIUtil.saveFile(parentWindow, title, extensions, initialName);
+            if (f != null)
+                return f;
+            // Proceed with the OS-independent path below. This is a workaround for
+            // a bug on some Macs where the native file-choosing dialog in MacUIUtil
+            // is never shown to the user. On Macs where the dialog is actually
+            // shown as expected, if the user clicked "cancel" then they will
+            // be shown a second dialog that they will have to cancel again. :(
+            // See https://github.com/protegeproject/protege/issues/1106
         }
         JFileChooser fileDialog = new JFileChooser(getCurrentFileDirectory());
         fileDialog.setDialogTitle(title);


### PR DESCRIPTION
This PR implements a workaround for the file-saving issue reported in #1106.

On macOS, if we don’t get a File from the macOS-specific `MacUIUtil#saveFile()` method, we assume this is due to a failure of that method (or of the underlying JRE) to even show the native file-choosing dialog (as was shown to happen in #1106), and we fallback to the OS-independent method instead of aborting the file-saving operation entirely.

This allow users affected by the “never-showing-native-dialog“ bug to still save their files, at the price of asking users not affected by that same bug to click “cancel” on two consecutive dialogs if they do want to cancel the save operation at the file-choosing step.