### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<slf4j.version>1.7.12</slf4j.version>
 		<logback.version>1.1.3</logback.version>
 		<lib.location>target/lib</lib.location>
-		<jackson.version>2.9.8</jackson.version>
+		<jackson.version>2.9.10</jackson.version>
 	</properties>
 	
 	<dependencyManagement>


### PR DESCRIPTION
Updated jackson:
 had)

Changes, core
Streaming
#540: UTF8StreamJsonParser: fix byte to int conversion for malformed escapes #556: 'IndexOutOfBoundsException' in UTF8JsonGenerator.writeString(Reader, len) when using a negative length Databind
#2331: JsonMappingException through nested getter with generic wildcard return type #2334: Block one more gadget type (logback, CVE-2019-12384) #2341: Block one more gadget type (jdom, CVE-2019-12814) #2374: ObjectMapper. getRegisteredModuleIds() throws NPE if no modules registered #2387: Block one more gadget type (ehcache, CVE-2019-14379) #2389: Block one more gadget type (logback, CVE-2019-14439) #2404: FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY setting ignored when creator properties are buffered #2410: Block one more gadget type (HikariCP, CVE-2019-14540) #2420: Block one more gadget type (no CVE allocated yet) #2449: Block one more gadget type (HikariCP, CVE-2019-14439 / CVE-2019-16335) #2460: Block one mode gadget type (ehcache, CVE-2019-17267) #2462: Block two more gadget types (commons-configuration) #2469: Block one mode gadget type (xalan2)
Changes, dataformats
XML
#336: WRITE_BIGDECIMAL_AS_PLAIN Not Used When Writing Pretty #340: Incompatible woodstox-core and stax2-api dependencies (upgrade to woodstox-core 5.3.0) Changes, other
Scala
The first release to support Scala 2.13. Thanks to Adriaan Moors and Seth Tisue!

#399: JsonScalaEnumeration annotation not picked up when using a Mixin
#429: Serialization behavior of case objects is different when using scala 2.13