### PR TITLE
update libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,8 @@
 	<properties>
 	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-		<slf4j.version>1.7.12</slf4j.version>
-		<logback.version>1.1.3</logback.version>
+		<slf4j.version>2.0.9</slf4j.version>
+		<logback.version>1.4.11</logback.version>
 		<lib.location>target/lib</lib.location>
 		<jackson.version>2.9.8</jackson.version>
 	</properties>


### PR DESCRIPTION
https://logback.qos.ch/news.html
https://www.slf4j.org/news.html

Fixed [CVE-2018-8088](https://nvd.nist.gov/vuln/detail/CVE-2018-8088) by removing the EventData EventException EventLogger classes in the same way as done in SLF4J 1.7.26.

fixed CVE-2021-42550 