### PR TITLE
Fix Rio Turtle format updating.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/DocumentFormatUpdater.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/DocumentFormatUpdater.java
@@ -36,7 +36,8 @@ public class DocumentFormatUpdater {
         OWLDocumentFormat mappedFormat = formatMapper.mapFormat(format);
         man.setOntologyFormat(ontology, mappedFormat);
         if(mappedFormat != format) {
-            logger.info("Updated document format class from: {} to: {}",
+            logger.info("Updated ontology {} document format class from: {} to: {}",
+                        ontology.getOntologyID().getOntologyIRI(),
                         format.getClass().getName(),
                         mappedFormat.getClass().getName());
         }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OWLModelManagerImpl.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OWLModelManagerImpl.java
@@ -341,7 +341,9 @@ public class OWLModelManagerImpl extends AbstractModelManager implements OWLMode
             loadedOntology.ifPresent(ontology -> {
                 logger.info("Loading for ontology and imports closure successfully completed in {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
                 DocumentFormatUpdater formatUpdater = new DocumentFormatUpdater(new DocumentFormatMapper());
-                formatUpdater.updateFormat(ontology);
+                for (OWLOntology o : ontology.getImportsClosure()) {
+                    formatUpdater.updateFormat(o);
+                }
             });
             logger.info(LogBanner.end());
             SwingUtilities.invokeLater(idRangesPolocyManager::reload);


### PR DESCRIPTION
When updating the document format of the loaded ontology, make sure to also update the format of all ontologies in the imports closure.

closes #1023