### PR TITLE
Fix the Orphanet link extractor.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OrphanetLinkExtractor.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OrphanetLinkExtractor.java
@@ -10,7 +10,7 @@ public class OrphanetLinkExtractor {
 
     public static final Pattern ORPHANET_ID_PATTERN = Pattern.compile("Orphanet:\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
 
-    public static final String ORPHANET_URL_BASE = "https://www.orpha.net/consor/www/cgi-bin/OC_Exp.php?Expert=";
+    public static final String ORPHANET_URL_BASE = "https://www.orpha.net/consor/cgi-bin/OC_Exp.php?Expert=";
 
     public static final String replacementString = ORPHANET_URL_BASE + "$1";
 


### PR DESCRIPTION
It seems the Orphanet website no longer serves resources of the form `/consor/www/cgi-bin/OC_Exp.php`, only `/consor/cgi-bin/OC_Exp.php`, so we update the link extractor accordingly.

closes #1192