### PR TITLE
Upgrade OWLAPI to version 4.5.28.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,8 @@
 	<properties>
 	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-		<slf4j.version>1.7.12</slf4j.version>
-		<logback.version>1.1.3</logback.version>
+		<slf4j.version>2.0.13</slf4j.version>
+		<logback.version>1.3.14</logback.version>
 		<lib.location>target/lib</lib.location>
 		<jackson.version>2.9.8</jackson.version>
 	</properties>
@@ -138,7 +138,13 @@
 			<dependency>
 				<groupId>net.sourceforge.owlapi</groupId>
 				<artifactId>owlapi-osgidistribution</artifactId>
-				<version>4.5.26</version>
+				<version>4.5.28</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.aries.spifly</groupId>
+				<artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+				<version>1.3.7</version>
 			</dependency>
 
 			<dependency>

--- a/protege-desktop/src/main/assembly/dependency-sets.xml
+++ b/protege-desktop/src/main/assembly/dependency-sets.xml
@@ -21,6 +21,7 @@
                 <include>org.slf4j:slf4j-api:jar</include>
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.slf4j:jul-to-slf4j:jar</include>
+                <include>org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:jar</include>
                 <include>commons-io:commons-io:jar</include>
                 <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-inject:jar</include>
                 <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.aopalliance:jar</include>
@@ -40,6 +41,7 @@
                 <include>org.glassfish.pfl:pfl-tf:jar</include>
                 <include>org.glassfish.pfl:pfl-dynamic:jar</include>
                 <include>org.ow2.asm:asm:jar</include>
+                <include>org.ow2.asm:asm-commons:jar</include>
                 <include>org.ow2.asm:asm-util:jar</include>
                 <include>org.ow2.asm:asm-tree:jar</include>
                 <include>org.ow2.asm:asm-analysis:jar</include>

--- a/protege-desktop/src/main/assembly/protege-os-x.xml
+++ b/protege-desktop/src/main/assembly/protege-os-x.xml
@@ -29,6 +29,7 @@
                 <include>org.slf4j:slf4j-api:jar</include>
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.slf4j:jul-to-slf4j:jar</include>
+                <include>org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:jar</include>
                 <include>commons-io:commons-io:jar</include>
                 <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-inject:jar</include>
                 <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.aopalliance:jar</include>
@@ -48,6 +49,7 @@
                 <include>org.glassfish.pfl:pfl-tf:jar</include>
                 <include>org.glassfish.pfl:pfl-dynamic:jar</include>
                 <include>org.ow2.asm:asm:jar</include>
+                <include>org.ow2.asm:asm-commons:jar</include>
                 <include>org.ow2.asm:asm-util:jar</include>
                 <include>org.ow2.asm:asm-tree:jar</include>
                 <include>org.ow2.asm:asm-analysis:jar</include>

--- a/protege-desktop/src/main/felix/conf/config.xml
+++ b/protege-desktop/src/main/felix/conf/config.xml
@@ -15,6 +15,15 @@
               value="onFirstInit"/>
     <property name="org.osgi.service.http.port" value="8081"/>
   </frameworkProperties>
+  <!-- Try initialising the logging providers early on -->
+  <bundles>
+    <search path="bundles"/>
+    <search path="${user.home}/.Protege/bundles"/>
+    <bundle name="logback-classic.jar"/>
+    <bundle name="logback-core.jar"/>
+    <bundle name="slf4j-api.jar"/>
+    <bundle name="org.apache.aries.spifly.dynamic.bundle.jar"/>
+  </bundles>
   <!--
   We need to start things at different levels.
   Protege common needs starting first because it sets up the required XML parsing machinery.  Without this

--- a/protege-editor-core/src/main/java/org/protege/editor/core/log/LogManager.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/log/LogManager.java
@@ -2,6 +2,7 @@ package org.protege.editor.core.log;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.AppenderBase;
@@ -121,9 +122,17 @@ public class LogManager {
 		listenerList.stream().forEach(LogStatusListener::statusCleared);
 	}
 
-    private Logger getRootLogger() {
-        return (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-    }
+	private Logger getRootLogger() {
+		org.slf4j.Logger l = LoggerFactory.getILoggerFactory().getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+		if (!(l instanceof Logger)) {
+			/* This could (and does!) happen if the SLF4J api could not find any backend
+			 * service provider. We get a dummy logger in that case; it won't log
+			 * anything but that's still better than crashing on an invalid cast. */
+			return new LoggerContext().getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+		} else {
+			return (Logger)l;
+		}
+	}
 
     public void bind() {
     	    applyPreferences();

--- a/protege-launcher/pom.xml
+++ b/protege-launcher/pom.xml
@@ -23,6 +23,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.aries.spifly</groupId>
+			<artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.main</artifactId>
 		</dependency>


### PR DESCRIPTION
This commit bumps our OWLAPI dependency to version 4.5.28.

Because the OSGI distribution of the OWLAPI has a hard requirement for SLF4J-API >= 2.x, we need to also bump our Logback-classic dependency to version 1.3.x, because the way the SLF4J-API interacts with its backends has changed in version 2.x, and Logback-classic < 1.3 is not compatible with the new way.

We also need a new dependency on the Apache Aries "SPI Fly" component (`org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle`). It provides an implementation of the OSGi ServiceLoader Mediator service, which – when in an OSGi context — is required by SLF4J-API 2.x to detect and load its backend providers. Without such an implementation, SLF4J-API 2.x _cannot_ be loaded in an OSGi application.

Alas, for some reason this is not enough, and in all my tests SLF4J has been constantly unable to find and use the Logback backend. This has two consequences:

First, it prevents Protégé from actually logging anything.

Second and more importantly, this results in an almost immediate crash in protege-editor-core’s `LogManager` class, because in that class we forcefully cast the `org.slf4j.Logger` object returned by SLF4J’s `LoggerFactory` into a backend-specific `ch.qos.logback.classic.Logger` object; such a cast can only be valid *if* the SLF4J-API has been initialised with the Logback backend. Since it has not (for reasons unknown), the factory returns a `org.slf4f.helpers.NOPLogger` object instead, and the cast therefore throws an exception.

The workaround implemented here is simply to protect the cast by checking the actual runtime type of the Logger returned by the LoggerFactory, and to create a dummy Logger if it is not the expected type (which, in my tests, is *always* the case). This at least allows Protégé to run and work as expected, but it does not change the fact that, because of the failed initialisation of SLF4J/Logback, Protégé WILL NOT LOG ANYTHING. :(