### PR TITLE
removed unnecessary  mockito-all library and FIX CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,16 +289,10 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.9.5</version>
+				<version>1.10.19</version>
 				<scope>test</scope>
 			</dependency>
 
-			<dependency>
-				<groupId>org.mockito</groupId>
-				<artifactId>mockito-all</artifactId>
-				<version>2.0.2-beta</version>
-				<scope>test</scope>
-			</dependency>
 
 			<dependency>
 				<groupId>com.google.auto.value</groupId>
@@ -315,9 +309,9 @@
 			</dependency>
 			
 			<dependency>	
-			  	<groupId>javax.xml.bind</groupId>	
-			  	<artifactId>jaxb-api</artifactId>	
-			  	<version>2.3.0</version>	
+			  	<groupId>jakarta.xml.bind</groupId>
+    				<artifactId>jakarta.xml.bind-api</artifactId>	
+			  	<version>2.3.3</version>	
 			</dependency>	
 
 			<dependency>	
@@ -363,7 +357,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.7.1</version>
 					<configuration>
 						<descriptors>
 							<descriptor>protege-distribution/src/main/assembly/protege-as-directory.xml</descriptor>
@@ -374,12 +368,12 @@
 				
 				<plugin>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.0.1</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.apache.maven.scm</groupId>
 							<artifactId>maven-scm-provider-gitexe</artifactId>
-							<version>1.9</version>
+							<version>2.1.0</version>
 						</dependency>
 					</dependencies>
 					<configuration>

--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -71,7 +71,7 @@
 
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -221,7 +221,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                
                 <executions>
                     <execution>
                         <id>unit-tests</id>
@@ -236,7 +236,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>

--- a/protege-launcher/pom.xml
+++ b/protege-launcher/pom.xml
@@ -106,18 +106,18 @@
 
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 		
 		<dependency>	
-		  	<groupId>javax.xml.bind</groupId>	
-		  	<artifactId>jaxb-api</artifactId>	
+		  	<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>	
 		</dependency>	
 
 		<dependency>	
 		  	<groupId>com.sun.xml.bind</groupId>	
-		 	 <artifactId>jaxb-core</artifactId>	
+		 	<artifactId>jaxb-core</artifactId>	
 		</dependency>	
 
 		<dependency>	


### PR DESCRIPTION
removed mockito-all, are included into mockito-core.

FIX CVE into apache maven assembly plugin
CVE-2023-37460
CVE-2022-4245
CVE-2022-4244
CVE-2020-15250
CVE-2018-1002200
CVE-2017-1000487