### PR TITLE
Improve management of plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.0</version>
+					<version>3.13.0</version>
 					<configuration>
 						<release>11</release>
 					</configuration>
@@ -414,7 +414,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>3.3.0</version>
+					<version>3.3.1</version>
 				</plugin>	
 				
 				<plugin>
@@ -432,7 +432,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.4</version>
 				</plugin>
 				
 				<plugin>
@@ -444,7 +444,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>2.5</version>
+					<version>3.3.2</version>
 				</plugin>
 
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -558,7 +558,7 @@
 							OSGi Framework launcher). -->
 						<plugin>
 							<artifactId>maven-resources-plugin</artifactId>
-							<version>3.9.6</version>
+							<version>3.3.1</version>
 							<executions>
 								<execution>
 									<id>copy-resources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,59 @@
 				   	 <artifactId>maven-surefire-plugin</artifactId>	
 				   	 <version>3.2.5</version>	
 				</plugin>
+				
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.3.1</version>
+				</plugin>
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.3.0</version>
+				</plugin>	
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>3.6.1</version>
+				</plugin>				
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.6.3</version>
+				</plugin>			
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+				
+				<plugin>
+					<groupId>org.sonatype.plugins</groupId>
+					<artifactId>nexus-staging-maven-plugin</artifactId>
+					<version>1.6.13</version>
+				</plugin>
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>2.5</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+				
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-failsafe-plugin</artifactId>
+	                <version>3.2.5</version>
+                </plugin>
 
 			</plugins>
 		</pluginManagement>
@@ -417,7 +470,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>3.3.0</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -431,7 +483,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.6.3</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -449,7 +500,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -463,8 +513,7 @@
 
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
+						<artifactId>nexus-staging-maven-plugin</artifactId>						
 						<extensions>true</extensions>
 						<executions>
 							<execution>
@@ -494,11 +543,6 @@
 			<build>
 				<pluginManagement>
 					<plugins>
-						<!-- Including this plug-in eliminates the "maven-dependency-plugin 
-							(goals "copy-dependencies", "unpack") is not supported by m2e" Eclipse error. -->
-						<!-- See stackoverflow for full discussion: http://stackoverflow.com/q/8706017. -->
-						<!-- This plugin's configuration is used to store Eclipse m2e settings 
-							only. It has no influence on the Maven build itself. -->
 						<plugin>
 							<groupId>org.eclipse.m2e</groupId>
 							<artifactId>lifecycle-mapping</artifactId>
@@ -538,8 +582,7 @@
 							in Eclipse (PDE + m2e + OSGi Framework launcher). -->
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-dependency-plugin</artifactId>
-							<version>3.6.1</version>
+							<artifactId>maven-dependency-plugin</artifactId>							
 							<executions>
 								<execution>
 									<id>copy-provided-dependencies</id>
@@ -558,7 +601,6 @@
 							OSGi Framework launcher). -->
 						<plugin>
 							<artifactId>maven-resources-plugin</artifactId>
-							<version>3.3.1</version>
 							<executions>
 								<execution>
 									<id>copy-resources</id>
@@ -585,7 +627,6 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-clean-plugin</artifactId>
-							<version>2.5</version>
 							<configuration>
 								<filesets>
 									<fileset>

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,11 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.4.1</version>
+				</plugin>
+				
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
@@ -456,6 +461,27 @@
 
 			</plugins>
 		</pluginManagement>
+
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.6.3</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 	
 	<!-- Generate source and Javadoc JAR files, and sign artifacts.  Required by Sonatype OSSRH for deployment. -->

--- a/pom.xml
+++ b/pom.xml
@@ -544,30 +544,6 @@
 				<pluginManagement>
 					<plugins>
 						<plugin>
-							<groupId>org.eclipse.m2e</groupId>
-							<artifactId>lifecycle-mapping</artifactId>
-							<version>1.0.0</version>
-							<configuration>
-								<lifecycleMappingMetadata>
-									<pluginExecutions>
-										<pluginExecution>
-											<pluginExecutionFilter>
-												<groupId>org.apache.maven.plugins</groupId>
-												<artifactId>maven-dependency-plugin</artifactId>
-												<versionRange>[3.1,)</versionRange>
-												<goals>
-													<goal>copy-dependencies</goal>
-												</goals>
-											</pluginExecutionFilter>
-											<action>
-												<ignore />
-											</action>
-										</pluginExecution>
-									</pluginExecutions>
-								</lifecycleMappingMetadata>
-							</configuration>
-						</plugin>
-						<plugin>
 							<groupId>org.apache.felix</groupId>
 							<artifactId>maven-bundle-plugin</artifactId>
 							<extensions>true</extensions>

--- a/protege-desktop/pom.xml
+++ b/protege-desktop/pom.xml
@@ -133,7 +133,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-antrun-plugin</artifactId>
-						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<phase>compile</phase>
@@ -151,7 +150,6 @@
 
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
-						<version>3.6.0</version>
 						<executions>
 							<execution>
 								<id>protege-desktop-assembly</id>

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -236,7 +236,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>


### PR DESCRIPTION

1. Plugin versions are now specified in the parent pom. This also has an advantage that that plugin versions will be checked even if plugins are not used (or used only in profiles).
2. Plugins are updated to the latest versions, except maven-bundle-plugin (with the latest version the bundles get some osgi dependency problems - this needs to be checked)
3. Set the minimal maven version for more reproducible builds and better reporting for `mvn versions:display-plugin-updates`
4. Some obsolete m2e lifecycle-mappings are removed
