### PR TITLE
Test all profiles in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  test:
+    strategy:
+      matrix:
+        profile: [ default, ide, release ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,4 +21,4 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Run test suite
-        run: mvn --batch-mode test
+        run: mvn --batch-mode verify --activate-profiles ${{ matrix.profile }} --define release.signing.disabled=true clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,9 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
+						<configuration>
+							<skip>${release.signing.disabled}</skip>
+						</configuration>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>


### PR DESCRIPTION
When running the test suite on GitHub, make sure all profiles are tested, to catch any breakage of a profile-specific configuration.

When testing the "release" profile, signing of the packages is explicitly disabled to avoid needless access to the release signing key.