### PR TITLE
Upgrade maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>4.1.0</version>
+					<version>5.1.9</version>
 					<extensions>true</extensions>
 					<configuration>
 						<instructions>							

--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -105,6 +105,8 @@
 						</_exportcontents>
 						<Import-Package>
 							!com.sun.*,
+							!com.apple.*,
+							!sun.swing,
 							org.eclipse.core.runtime;registry="split",
 							*
 						</Import-Package>


### PR DESCRIPTION
The new version tries to export the system packages com.apple.eawt, com.apple.eio, sun.swing, which need to be excluded because they are not exported by any other bundle.

I tested protege-mac app and protege-platform-independent (with openjdk 11.0.23 2024-04-16 LTS), which seem to work fine, but I did not test windows and linux apps. 