### PR TITLE
Process escape characters when searching for entities, fix #1217

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderImpl.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderImpl.java
@@ -57,7 +57,8 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
     }
 
     public OWLClass getOWLClass(String rendering) {
-        OWLClass cls = renderingCache.getOWLClass(stripAndEscapeRendering(rendering));
+    	rendering = stripAndEscapeRendering(rendering);
+        OWLClass cls = renderingCache.getOWLClass(rendering);
         if (cls == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)) {
             cls = renderingCache.getOWLClass(RenderingEscapeUtils.getEscapedRendering(rendering));
         }
@@ -70,6 +71,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
     }
 
     public OWLObjectProperty getOWLObjectProperty(String rendering) {
+    	rendering = stripAndEscapeRendering(rendering);
         OWLObjectProperty prop = renderingCache.getOWLObjectProperty(rendering);
         if (prop == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
             prop = renderingCache.getOWLObjectProperty(RenderingEscapeUtils.getEscapedRendering(rendering));
@@ -79,6 +81,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
 
 
     public OWLDataProperty getOWLDataProperty(String rendering) {
+    	rendering = stripAndEscapeRendering(rendering);
         OWLDataProperty prop = renderingCache.getOWLDataProperty(rendering);
         if (prop == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
             prop = renderingCache.getOWLDataProperty(RenderingEscapeUtils.getEscapedRendering(rendering));
@@ -88,6 +91,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
 
 
     public OWLAnnotationProperty getOWLAnnotationProperty(String rendering) {
+    	rendering = stripAndEscapeRendering(rendering);
         OWLAnnotationProperty prop = renderingCache.getOWLAnnotationProperty(rendering);
         if (prop == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
             prop = renderingCache.getOWLAnnotationProperty(RenderingEscapeUtils.getEscapedRendering(rendering));
@@ -97,6 +101,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
 
 
     public OWLNamedIndividual getOWLIndividual(String rendering) {
+    	rendering = stripAndEscapeRendering(rendering);
         OWLNamedIndividual individual = renderingCache.getOWLIndividual(rendering);
         if (individual == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
             individual = renderingCache.getOWLIndividual(RenderingEscapeUtils.getEscapedRendering(rendering));
@@ -106,6 +111,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
 
 
     public OWLDatatype getOWLDatatype(String rendering) {
+    	rendering = stripAndEscapeRendering(rendering);
         OWLDatatype dataType = renderingCache.getOWLDatatype(rendering);
         if (dataType == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
             dataType = renderingCache.getOWLDatatype(RenderingEscapeUtils.getEscapedRendering(rendering));
@@ -115,6 +121,7 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
 
 
     public OWLEntity getOWLEntity(String rendering) {
+    	rendering = stripAndEscapeRendering(rendering);
         OWLEntity entity = renderingCache.getOWLEntity(rendering);
         if (entity == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
             entity = renderingCache.getOWLEntity(RenderingEscapeUtils.getEscapedRendering(rendering));

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderImpl.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderImpl.java
@@ -41,28 +41,15 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
         this.renderingCache = renderingCache;
     }
 
-
-    private static final String ESCAPE_CHAR = "'";
-
-
     private String stripAndEscapeRendering(String rendering) {
-        String strippedRendering;
-        if(rendering.startsWith("'") && rendering.endsWith("'") && rendering.length() > 1) {
-            strippedRendering = rendering.substring(1, rendering.length() - 1);
+        if (rendering.startsWith("'") && rendering.endsWith("'") && rendering.length() > 1) {
+        	rendering = rendering.substring(1, rendering.length() - 1);
         }
-        else {
-            strippedRendering = rendering;
-        }
-        return RenderingEscapeUtils.getEscapedRendering(strippedRendering);
+        return RenderingEscapeUtils.getEscapedRendering(rendering);
     }
 
     public OWLClass getOWLClass(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLClass cls = renderingCache.getOWLClass(rendering);
-        if (cls == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)) {
-            cls = renderingCache.getOWLClass(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return cls;
+    	return renderingCache.getOWLClass(stripAndEscapeRendering(rendering));
     }
 
     @Override
@@ -71,62 +58,32 @@ public class OWLEntityFinderImpl implements OWLEntityFinder {
     }
 
     public OWLObjectProperty getOWLObjectProperty(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLObjectProperty prop = renderingCache.getOWLObjectProperty(rendering);
-        if (prop == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
-            prop = renderingCache.getOWLObjectProperty(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return prop;
+    	return renderingCache.getOWLObjectProperty(stripAndEscapeRendering(rendering));
     }
 
 
     public OWLDataProperty getOWLDataProperty(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLDataProperty prop = renderingCache.getOWLDataProperty(rendering);
-        if (prop == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
-            prop = renderingCache.getOWLDataProperty(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return prop;
+    	return renderingCache.getOWLDataProperty(stripAndEscapeRendering(rendering));
     }
 
 
     public OWLAnnotationProperty getOWLAnnotationProperty(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLAnnotationProperty prop = renderingCache.getOWLAnnotationProperty(rendering);
-        if (prop == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
-            prop = renderingCache.getOWLAnnotationProperty(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return prop;
+    	return renderingCache.getOWLAnnotationProperty(stripAndEscapeRendering(rendering));
     }
 
 
     public OWLNamedIndividual getOWLIndividual(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLNamedIndividual individual = renderingCache.getOWLIndividual(rendering);
-        if (individual == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
-            individual = renderingCache.getOWLIndividual(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return individual;
+    	return renderingCache.getOWLIndividual(stripAndEscapeRendering(rendering));
     }
 
 
     public OWLDatatype getOWLDatatype(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLDatatype dataType = renderingCache.getOWLDatatype(rendering);
-        if (dataType == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
-            dataType = renderingCache.getOWLDatatype(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return dataType;
+    	return renderingCache.getOWLDatatype(stripAndEscapeRendering(rendering));
     }
 
 
     public OWLEntity getOWLEntity(String rendering) {
-    	rendering = stripAndEscapeRendering(rendering);
-        OWLEntity entity = renderingCache.getOWLEntity(rendering);
-        if (entity == null && !rendering.startsWith(ESCAPE_CHAR) && !rendering.endsWith(ESCAPE_CHAR)){
-            entity = renderingCache.getOWLEntity(RenderingEscapeUtils.getEscapedRendering(rendering));
-        }
-        return entity;
+    	return renderingCache.getOWLEntity(stripAndEscapeRendering(rendering));
     }
 
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/hierarchy/OWLObjectHierarchyProviderListener.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/hierarchy/OWLObjectHierarchyProviderListener.java
@@ -15,8 +15,8 @@ import org.semanticweb.owlapi.model.OWLObject;
 public interface OWLObjectHierarchyProviderListener<N extends OWLObject> {
 
     /**
-     * Notifies the listener that the parents and or children
-     * of the specified node might have changed.  This is usually
+     * Notifies the listener that the equivalent objects, parents and or
+     * children of the specified node might have changed.  This is usually
      * called in response to an add/remove axiom change.
      */
     public void nodeChanged(N node);

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLCellRenderer.java
@@ -255,6 +255,8 @@ public class OWLCellRenderer implements TableCellRenderer, TreeCellRenderer, Lis
 		tmp.crossedOutEntities.addAll(crossedOutEntities);
 		tmp.unsatisfiableNames.clear();
 		tmp.unsatisfiableNames.addAll(unsatisfiableNames);
+		tmp.equivalentObjects.clear();
+		tmp.equivalentObjects.addAll(equivalentObjects);
 		tmp.boxedNames.clear();
 		tmp.boxedNames.addAll(boxedNames);
 		unlock();

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/RenderingEscapeUtils.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/RenderingEscapeUtils.java
@@ -33,8 +33,12 @@ public class RenderingEscapeUtils {
      * @return The escaped rendering.
      */
     public static String getEscapedRendering(String originalRendering) {
-        originalRendering = originalRendering.replace("'", "\\'");
+    	String rendering = originalRendering;
+    	rendering = rendering.replace("\\", "\\\\");
+    	rendering = rendering.replace("'", "\\'");
+    	rendering = rendering.replace("\"", "\\\"");
         if (originalRendering.indexOf(' ') != -1
+        		|| originalRendering.indexOf('\\') != -1
                 || originalRendering.indexOf(',') != -1
                 || originalRendering.indexOf('<') != -1
                 || originalRendering.indexOf('>') != -1
@@ -47,22 +51,20 @@ public class RenderingEscapeUtils {
                 || originalRendering.indexOf(']') != -1
                 || originalRendering.indexOf('(') != -1
                 || originalRendering.indexOf(')') != -1) {
-            return "'" + originalRendering + "'";
+        	rendering = "'" + rendering + "'";
         }
-        else {
-            return originalRendering;
-        }
+        return rendering;
     }
 
     @Nonnull
     public static String unescape(@Nonnull String rendering) {
-        rendering = rendering.replace("\\'", "'");
         if(rendering.startsWith("'") && rendering.endsWith("'")) {
-            return rendering.substring(1, rendering.length() - 1);
+        	rendering = rendering.substring(1, rendering.length() - 1);
         }
-        else {
-            return rendering;
-        }
+        rendering = rendering.replace("\\\"", "\"");
+    	rendering = rendering.replace("\\'", "'");
+    	rendering = rendering.replace("\\\\", "\\");
+        return rendering;
     }
 
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/tree/OWLModelManagerTree.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/tree/OWLModelManagerTree.java
@@ -125,7 +125,12 @@ public class OWLModelManagerTree<N extends OWLObject> extends OWLObjectTree<N> i
         try {
             for (OWLObjectTreeNode<N> node : getNodes(entity)) {
                 DefaultTreeModel model = (DefaultTreeModel) getModel();
-                model.nodeStructureChanged(node);
+                model.nodeChanged(node);
+                for (N equivalentEntity: node.getEquivalentObjects()) {
+                	for (OWLObjectTreeNode<N> equivalentNode : getNodes(equivalentEntity)) {
+                		model.nodeChanged(equivalentNode);
+                	}
+                }
             }
         }
         catch (ClassCastException e) {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/tree/OWLObjectTree.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/tree/OWLObjectTree.java
@@ -283,8 +283,8 @@ public class OWLObjectTree<N extends OWLObject> extends JTree implements OWLObje
 
     @SuppressWarnings("unchecked")
     private void updateNode(N node) {
-        // This method is called when the parents or children of
-        // a node might have changed.  We handle the following possibilities
+        // This method is called when the node, its parents or children
+        // might have changed.  We handle the following possibilities
         // 1) The node had a child added
         // 2) The node had a child removed
         // If we are displaying the node which had the child added or removed
@@ -292,8 +292,12 @@ public class OWLObjectTree<N extends OWLObject> extends JTree implements OWLObje
 
         final Set<OWLObjectTreeNode<N>> treeNodes = nodeMap.get(node);
 
-        // The parents/children might have changed
+        // The node/parents/children might have changed
         if (treeNodes != null && !treeNodes.isEmpty()) {
+        	// The node equivalent objects might have changed
+        	// @@TODO: use provider to check if this were the case
+        	treeNodes.forEach(((DefaultTreeModel) getModel())::nodeChanged);
+        	
             // Remove children that aren't there any more
             Set<N> children = provider.getChildren(node);
 

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/renderer/RenderingEscapeUtils_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/renderer/RenderingEscapeUtils_TestCase.java
@@ -1,10 +1,10 @@
 package org.protege.editor.owl.ui.renderer;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
  * Matthew Horridge
@@ -13,100 +13,101 @@ import static org.hamcrest.Matchers.is;
  */
 public class RenderingEscapeUtils_TestCase {
 
+	private static void assertEscaped(String original, String escaped) {
+		String actualEscaped = RenderingEscapeUtils.getEscapedRendering(original);
+		assertThat(actualEscaped, Matchers.is(escaped));
+		String actualUnescaped = RenderingEscapeUtils.unescape(escaped);
+		assertThat(actualUnescaped, Matchers.is(original));
+	}
+	
     @Test
     public void shouldNotEscapeRendering() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("AB");
-        assertThat(rendering, is("AB"));
+    	assertEscaped("AB", "AB");
     }
 
     @Test
-    public void shouldEscapeRenderingContainingSpace() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A B");
-        assertThat(rendering, is("'A B'"));
-    }
+	public void shouldEscapeRenderingContainingSpace() {
+		assertEscaped("A B", "'A B'");
+	}
 
     @Test
     public void shouldEscapeRenderingContainingComma() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A,B");
-        assertThat(rendering, is("'A,B'"));
+    	assertEscaped("A,B", "'A,B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingLeftBracket() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A(B");
-        assertThat(rendering, is("'A(B'"));
+    	assertEscaped("A(B", "'A(B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingRightBracket() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A)B");
-        assertThat(rendering, is("'A)B'"));
+    	assertEscaped("A)B", "'A)B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingLeftSquareBracket() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A[B");
-        assertThat(rendering, is("'A[B'"));
+    	assertEscaped("A[B", "'A[B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingRightSquareBracket() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A]B");
-        assertThat(rendering, is("'A]B'"));
+    	assertEscaped("A]B", "'A]B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingLeftBrace() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A{B");
-        assertThat(rendering, is("'A{B'"));
+    	assertEscaped("A{B", "'A{B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingRightBrace() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A}B");
-        assertThat(rendering, is("'A}B'"));
+    	assertEscaped("A}B", "'A}B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingHat() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A^B");
-        assertThat(rendering, is("'A^B'"));
+    	assertEscaped("A^B", "'A^B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingAt() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A@B");
-        assertThat(rendering, is("'A@B'"));
+    	assertEscaped("A@B", "'A@B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingLessThan() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A<B");
-        assertThat(rendering, is("'A<B'"));
+    	assertEscaped("A<B", "'A<B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingGreaterThan() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A>B");
-        assertThat(rendering, is("'A>B'"));
+    	assertEscaped("A>B", "'A>B'");
     }
 
     @Test
     public void shouldEscapeRenderingContainingEquals() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A=B");
-        assertThat(rendering, is("'A=B'"));
+    	assertEscaped("A=B", "'A=B'");
     }
 
     @Test
     public void shouldEscapeSingleQuote() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A's");
-        assertThat(rendering, is("A\\'s"));
+    	assertEscaped("A'B", "A\\'B");
+    }
+    
+    @Test
+    public void shouldEscapeDoubleQuote() {
+    	assertEscaped("A\"B", "A\\\"B");
+    }
+    
+    @Test
+    public void shouldEscapeBackslash() {
+    	assertEscaped("A\\B", "'A\\\\B'");
     }
 
     @Test
     public void shouldEscapeSingleQuoteWithSpaces() {
-        String rendering = RenderingEscapeUtils.getEscapedRendering("A's and B's");
-        assertThat(rendering, is("'A\\'s and B\\'s'"));
+    	assertEscaped("A's and B's", "'A\\'s and B\\'s'");    	
     }
 
     @Test


### PR DESCRIPTION
Previously this was done only when searching for OWLClasses