### PR TITLE
Add persistence for the "show deprecated entities" option.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/hierarchy/ClassHierarchyPreferences.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/hierarchy/ClassHierarchyPreferences.java
@@ -16,6 +16,8 @@ public class ClassHierarchyPreferences {
 
     private static final String DISPLAY_RELATIONSHIPS_KEY = "DISPLAY_RELATIONSHIPS";
 
+    private static final String DISPLAY_DEPRECATED_ENTITIES_KEY = "DISPLAY_DEPRECATED_ENTITIES";
+
     private static Preferences getPreferences() {
         return PreferencesManager.getInstance().getApplicationPreferences(CLASS_HIERARCHY_PREFERENCES);
     }
@@ -30,5 +32,13 @@ public class ClassHierarchyPreferences {
 
     public void setDisplayRelationships(boolean displayRelationships) {
         getPreferences().putBoolean(DISPLAY_RELATIONSHIPS_KEY, displayRelationships);
+    }
+
+    public boolean isDisplayDeprecatedEntities() {
+        return getPreferences().getBoolean(DISPLAY_DEPRECATED_ENTITIES_KEY, false);
+    }
+
+    public void setDisplayDeprecatedEntities(boolean displayDeprecatedEntities) {
+        getPreferences().putBoolean(DISPLAY_DEPRECATED_ENTITIES_KEY, displayDeprecatedEntities);
     }
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/action/DisplayDeprecatedEntitiesAction.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/action/DisplayDeprecatedEntitiesAction.java
@@ -1,5 +1,6 @@
 package org.protege.editor.owl.ui.action;
 
+import org.protege.editor.owl.model.hierarchy.ClassHierarchyPreferences;
 import org.protege.editor.owl.ui.view.HasDisplayDeprecatedEntities;
 
 import java.awt.event.ActionEvent;
@@ -13,7 +14,7 @@ public class DisplayDeprecatedEntitiesAction extends ComponentHierarchyAction<Ha
 
     @Override
     protected Class<HasDisplayDeprecatedEntities> initialiseAction() {
-        putValue(SELECTED_KEY, false);
+        putValue(SELECTED_KEY, ClassHierarchyPreferences.get().isDisplayDeprecatedEntities());
         return HasDisplayDeprecatedEntities.class;
     }
 
@@ -21,5 +22,6 @@ public class DisplayDeprecatedEntitiesAction extends ComponentHierarchyAction<Ha
     protected void actionPerformedOnTarget(ActionEvent e, HasDisplayDeprecatedEntities target) {
         boolean value = (boolean) getValue(SELECTED_KEY);
         target.setShowDeprecatedEntities(value);
+        ClassHierarchyPreferences.get().setDisplayDeprecatedEntities(value);
     }
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/AbstractOWLEntityHierarchyViewComponent.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/AbstractOWLEntityHierarchyViewComponent.java
@@ -6,6 +6,7 @@ import org.protege.editor.core.ui.view.View;
 import org.protege.editor.core.ui.view.ViewMode;
 import org.protege.editor.core.util.HandlerRegistration;
 import org.protege.editor.owl.model.OWLModelManager;
+import org.protege.editor.owl.model.hierarchy.ClassHierarchyPreferences;
 import org.protege.editor.owl.model.hierarchy.OWLObjectHierarchyProvider;
 import org.protege.editor.owl.ui.OWLObjectComparatorAdapter;
 import org.protege.editor.owl.ui.action.AbstractOWLTreeAction;
@@ -170,8 +171,9 @@ public abstract class AbstractOWLEntityHierarchyViewComponent<E extends OWLEntit
 
         breadCrumbTrailProviderRegistration = getOWLWorkspace().registerBreadcrumbTrailProvider(this);
 
-        // Don't show deprecated entities by default
-        getHierarchyProvider().setFilter(this::isNotDeprecated);
+        if (!ClassHierarchyPreferences.get().isDisplayDeprecatedEntities()) {
+             getHierarchyProvider().setFilter(this::isNotDeprecated);
+        }
     }
 
     private void scrollSelectedPathToVisibleRect() {


### PR DESCRIPTION
The setting of the "View > Show deprecated (obsolete) entities" menu option is not persistent and is always reset to its default value (false) whenever Protégé is started or a new ontology is open.

This PR adds a new preference to store that setting so that it is made persistent.