### PR TITLE
Switch GA workflows to use the Temurin JDK.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Run test suite
         run: mvn --batch-mode --activate-profiles ${{ matrix.profile }} --define release.signing.disabled=true clean verify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_TOKEN


### PR DESCRIPTION
The maintainers of the 'setup-java' GitHub Action recommends migrating from 'adopt' to 'temurin' [1], given that "AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore".

[1] https://github.com/actions/setup-java