### PR TITLE
sort of data-/objectproperty assertion axioms

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/OWLPropertyAssertionRowComparator.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/OWLPropertyAssertionRowComparator.java
@@ -1,0 +1,42 @@
+package org.protege.editor.owl.ui;
+
+import org.protege.editor.owl.ui.frame.OWLFrameSectionRow;
+import org.semanticweb.owlapi.model.OWLIndividual;
+import org.semanticweb.owlapi.model.OWLObject;
+import org.semanticweb.owlapi.model.OWLPropertyAssertionAxiom;
+
+import java.util.Comparator;
+
+/**
+ * Compares rows of type {@link OWLPropertyAssertionAxiom}.
+ * Comparison priority is as follows:
+ * inference > property > object
+ * <p>
+ * Author: Michael Opitz <br>
+ * https://github.com/mmopitz<br>
+ * Date: 30-Sep-2024<br><br>
+ */
+public class OWLPropertyAssertionRowComparator<E extends OWLPropertyAssertionAxiom<?, ?>, PAIR> implements
+        Comparator<OWLFrameSectionRow<OWLIndividual, E, PAIR>> {
+    private final Comparator<OWLObject> delegate;
+
+    public OWLPropertyAssertionRowComparator(Comparator<OWLObject> delegate) {
+        this.delegate = delegate;
+    }
+
+
+    @Override
+    public int compare(OWLFrameSectionRow<OWLIndividual, E, PAIR> o1, OWLFrameSectionRow<OWLIndividual, E, PAIR> o2) {
+        if (o1.isInferred() && !o2.isInferred()) {
+            return 1;
+        }
+        else if (o2.isInferred() && !o1.isInferred()) {
+            return -1;
+        }
+        int comparison = delegate.compare(o1.getAxiom().getProperty(), o2.getAxiom().getProperty());
+        if (comparison != 0) {
+            return comparison;
+        }
+        return delegate.compare(o1.getAxiom().getObject(), o2.getAxiom().getObject());
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLDataPropertyAssertionAxiomFrameSection.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLDataPropertyAssertionAxiomFrameSection.java
@@ -2,6 +2,7 @@ package org.protege.editor.owl.ui.frame.individual;
 
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.model.inference.ReasonerPreferences.OptionalInferenceTask;
+import org.protege.editor.owl.ui.OWLPropertyAssertionRowComparator;
 import org.protege.editor.owl.ui.editor.OWLDataPropertyRelationshipEditor;
 import org.protege.editor.owl.ui.editor.OWLObjectEditor;
 import org.protege.editor.owl.ui.frame.AbstractOWLFrameSection;
@@ -106,7 +107,7 @@ public class OWLDataPropertyAssertionAxiomFrameSection extends AbstractOWLFrameS
      *         or <code>null</code> if the rows shouldn't be sorted.
      */
     public Comparator<OWLFrameSectionRow<OWLIndividual, OWLDataPropertyAssertionAxiom, OWLDataPropertyConstantPair>> getRowComparator() {
-        return null;
+        return new OWLPropertyAssertionRowComparator<>(getOWLModelManager().getOWLObjectComparator());
     }
 
     @Override

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLNegativeDataPropertyAssertionFrameSection.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLNegativeDataPropertyAssertionFrameSection.java
@@ -1,6 +1,7 @@
 package org.protege.editor.owl.ui.frame.individual;
 
 import org.protege.editor.owl.OWLEditorKit;
+import org.protege.editor.owl.ui.OWLPropertyAssertionRowComparator;
 import org.protege.editor.owl.ui.editor.OWLDataPropertyRelationshipEditor;
 import org.protege.editor.owl.ui.editor.OWLObjectEditor;
 import org.protege.editor.owl.ui.frame.AbstractOWLFrameSection;
@@ -73,7 +74,7 @@ public class OWLNegativeDataPropertyAssertionFrameSection extends AbstractOWLFra
      *         or <code>null</code> if the rows shouldn't be sorted.
      */
     public Comparator<OWLFrameSectionRow<OWLIndividual, OWLNegativeDataPropertyAssertionAxiom, OWLDataPropertyConstantPair>> getRowComparator() {
-        return null;
+        return new OWLPropertyAssertionRowComparator<>(getOWLModelManager().getOWLObjectComparator());
     }
 
     @Override

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLNegativeObjectPropertyAssertionFrameSection.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLNegativeObjectPropertyAssertionFrameSection.java
@@ -1,6 +1,7 @@
 package org.protege.editor.owl.ui.frame.individual;
 
 import org.protege.editor.owl.OWLEditorKit;
+import org.protege.editor.owl.ui.OWLPropertyAssertionRowComparator;
 import org.protege.editor.owl.ui.editor.OWLObjectEditor;
 import org.protege.editor.owl.ui.editor.OWLObjectPropertyIndividualPairEditor2;
 import org.protege.editor.owl.ui.frame.AbstractOWLFrameSection;
@@ -70,7 +71,7 @@ public class OWLNegativeObjectPropertyAssertionFrameSection extends AbstractOWLF
      *         or <code>null</code> if the rows shouldn't be sorted.
      */
     public Comparator<OWLFrameSectionRow<OWLIndividual, OWLNegativeObjectPropertyAssertionAxiom, OWLObjectPropertyIndividualPair>> getRowComparator() {
-        return null;
+        return new OWLPropertyAssertionRowComparator<>(getOWLModelManager().getOWLObjectComparator());
     }
 
     @Override

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLObjectPropertyAssertionAxiomFrameSection.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/frame/individual/OWLObjectPropertyAssertionAxiomFrameSection.java
@@ -2,6 +2,7 @@ package org.protege.editor.owl.ui.frame.individual;
 
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.model.inference.ReasonerPreferences.OptionalInferenceTask;
+import org.protege.editor.owl.ui.OWLPropertyAssertionRowComparator;
 import org.protege.editor.owl.ui.editor.OWLObjectEditor;
 import org.protege.editor.owl.ui.editor.OWLObjectPropertyIndividualPairEditor2;
 import org.protege.editor.owl.ui.frame.AbstractOWLFrameSection;
@@ -106,7 +107,7 @@ public class OWLObjectPropertyAssertionAxiomFrameSection extends AbstractOWLFram
      *         or <code>null</code> if the rows shouldn't be sorted.
      */
     public Comparator<OWLFrameSectionRow<OWLIndividual, OWLObjectPropertyAssertionAxiom, OWLObjectPropertyIndividualPair>> getRowComparator() {
-        return null;
+        return new OWLPropertyAssertionRowComparator<>(getOWLModelManager().getOWLObjectComparator());
     }
     
     @Override

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/OWLPropertyAssertionRowComparator_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/OWLPropertyAssertionRowComparator_TestCase.java
@@ -1,0 +1,95 @@
+package org.protege.editor.owl.ui;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.protege.editor.owl.ui.frame.OWLFrameSectionRow;
+import org.semanticweb.owlapi.model.*;
+
+import java.util.Comparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OWLPropertyAssertionRowComparator_TestCase {
+
+    @Mock
+    Comparator<OWLObject> delegate;
+    @Mock
+    OWLFrameSectionRow<OWLIndividual, OWLObjectPropertyAssertionAxiom, String> o1;
+    @Mock
+    OWLFrameSectionRow<OWLIndividual, OWLObjectPropertyAssertionAxiom, String> o2;
+    @Mock
+    OWLObjectPropertyAssertionAxiom opa1;
+    @Mock
+    OWLObjectPropertyAssertionAxiom opa2;
+    @Mock
+    OWLObjectProperty op1;
+    @Mock
+    OWLObjectProperty op2;
+    @Mock
+    OWLIndividual i1;
+    @Mock
+    OWLIndividual i2;
+
+    OWLPropertyAssertionRowComparator<OWLObjectPropertyAssertionAxiom, String> comparator;
+
+    @Before
+    public void setUp() {
+        comparator = new OWLPropertyAssertionRowComparator<>(delegate);
+    }
+
+    @Test
+    public void testInferred1() {
+        when(o1.isInferred()).thenReturn(true);
+        when(o2.isInferred()).thenReturn(false);
+        assertEquals(1, comparator.compare(o1, o2));
+    }
+
+    @Test
+    public void testInferred2() {
+        when(o1.isInferred()).thenReturn(false);
+        when(o2.isInferred()).thenReturn(true);
+        assertEquals(-1, comparator.compare(o1, o2));
+    }
+
+    @Test
+    public void testDifferentProperty() {
+        when(o1.getAxiom()).thenReturn(opa1);
+        when(o2.getAxiom()).thenReturn(opa2);
+        when(opa1.getProperty()).thenReturn(op1);
+        when(opa2.getProperty()).thenReturn(op2);
+        when(delegate.compare(op1, op2)).thenReturn(-2);
+        assertEquals(-2, comparator.compare(o1, o2));
+    }
+
+    @Test
+    public void testDifferentIndividuals() {
+        when(o1.getAxiom()).thenReturn(opa1);
+        when(o2.getAxiom()).thenReturn(opa2);
+        when(opa1.getProperty()).thenReturn(op1);
+        when(opa2.getProperty()).thenReturn(op2);
+        when(opa1.getObject()).thenReturn(i1);
+        when(opa2.getObject()).thenReturn(i2);
+        when(delegate.compare(op1, op2)).thenReturn(0);
+        when(delegate.compare(i1, i2)).thenReturn(-2);
+        assertEquals(-2, comparator.compare(o1, o2));
+    }
+
+    @Test
+    public void testSame() {
+        when(o1.getAxiom()).thenReturn(opa1);
+        when(o2.getAxiom()).thenReturn(opa2);
+        when(opa1.getProperty()).thenReturn(op1);
+        when(opa2.getProperty()).thenReturn(op2);
+        when(opa1.getObject()).thenReturn(i1);
+        when(opa2.getObject()).thenReturn(i2);
+        when(delegate.compare(op1, op2)).thenReturn(0);
+        when(delegate.compare(i1, i2)).thenReturn(0);
+        assertEquals(0, comparator.compare(o1, o2));
+    }
+
+}


### PR DESCRIPTION
refs #605 

Note: This is my first contribution to protege. So I expect some rough edges ;-) .

I tried to address the sorting of data-/object-propertyAssertion in the individual views.

Analogous to the sorting of classAssertionAxioms the assertions are sorted in following order

1. inferred/not inferred
2. the 'displayName' of the property (using the owlObjectComparator)
3. the 'displayName' of the object (using the owlObjectComparator)

I added the sorting to following Sections:

1. dataPropertyAssertionAxioms
2. objectPropertyAssertionAxioms
3. negativeDataPropertyAssertionAxioms
4. negativeObjectPropertyAssertionAxioms

For personal reasons I would love to see this change in the next protege release. Please let me know if further adjustments are required.

