### PR TITLE
Use `xdg-open` to spawn browser on GNU/Linux

### DIFF
--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/util/NativeBrowserLauncher.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/util/NativeBrowserLauncher.java
@@ -25,12 +25,12 @@ public class NativeBrowserLauncher {
     public static void openURL(String url) {
         try {
             if (OSUtils.isOSX()) {
-                Class fileMgr = Class.forName("com.apple.eio.FileManager");
+                Class<?> fileMgr = Class.forName("com.apple.eio.FileManager");
                 Method openURL = fileMgr.getDeclaredMethod("openURL", String.class);
                 openURL.invoke(null, url);
             }
             else if (OSUtils.isWindows()){
-                Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + url);
+                Runtime.getRuntime().exec(new String[] {"rundll32", "url.dll,FileProtocolHandler", url});
             }
             else { //assume Unix or Linux
                 String[] browsers = {

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/util/NativeBrowserLauncher.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/util/NativeBrowserLauncher.java
@@ -34,7 +34,7 @@ public class NativeBrowserLauncher {
             }
             else { //assume Unix or Linux
                 String[] browsers = {
-                        "firefox", "opera", "konqueror", "epiphany", "mozilla", "netscape" };
+                        "xdg-open", "firefox", "opera", "konqueror", "epiphany", "mozilla", "netscape" };
                 String browser = null;
                 for (int count = 0; count < browsers.length && browser == null; count++)
                     if (Runtime.getRuntime().exec(


### PR DESCRIPTION
This PR updates the `NativeBrowserLauncher` class so that, on GNU/Linux (or similar non-macOS, non-Windows platforms), we try opening a URL using `xdg-open` first, before any other possible browser. This ensures that the URL is opened using the user’s preferred browser (assuming a FreeDesktop.org-compliant environment, which should be the case of most if not all GNU/Linux distributions nowadays).

closes #1263 

Also bundled with that PR are two small changes on that same `NativeBrowserLauncher` class to silence some warnings about (1) the use of a “raw type” `Class` and (2) the use of the deprecated-in-Java-18 `java.lang.Runtime.exec(String)` method.