### PR TITLE
Add a Bioregistry.io-based link extractor.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/Bioregistry.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/Bioregistry.java
@@ -33,12 +33,14 @@ public class Bioregistry {
     private static final Logger logger = LoggerFactory.getLogger(Bioregistry.class);
 
     private static final String API_ENDPOINT = "http://bioregistry.io/api/registry/%s?format=json";
+    private static final int MAX_ERRORS = 6;
 
     private static Bioregistry instance;
 
     private Map<String,Resource> cache = new HashMap<>();
     private final HttpClient client;
     private final ObjectMapper objectMapper;
+    private int errors = 0;
 
     public static synchronized Bioregistry getInstance() {
         if (instance == null) {
@@ -70,7 +72,7 @@ public class Bioregistry {
     }
 
     private Resource getResource(@Nonnull String prefix) {
-        if ( !cache.containsKey(prefix)) {
+        if (!cache.containsKey(prefix) && errors < MAX_ERRORS) {
             Resource resource = null;
             HttpGet request = new HttpGet(String.format(API_ENDPOINT, prefix));
             request.addHeader("Accept", "application/json");
@@ -82,6 +84,7 @@ public class Bioregistry {
                 }
             } catch (IOException e ) {
                 logger.warn("Error when querying the bioregistry for '{}': {}", prefix, e.getMessage());
+                errors += 1;
             }
             cache.put(prefix, resource);
         }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/Bioregistry.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/Bioregistry.java
@@ -1,0 +1,90 @@
+package org.protege.editor.owl.model.bioregistry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Author: Damien Goutte-Gattat<br>
+ * University of Cambridge<br>
+ * FlyBase Group<br>
+ * Date: 03/04/2025
+ * <p>
+ * A client for the Bioregistry.io API. Not a full-featured client,
+ * limited to transforming CURIEs into resolvable links.
+ * </p>
+ */
+public class Bioregistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(Bioregistry.class);
+
+    private static final String API_ENDPOINT = "http://bioregistry.io/api/registry/%s?format=json";
+
+    private static Bioregistry instance;
+
+    private Map<String,Resource> cache = new HashMap<>();
+    private final HttpClient client;
+    private final ObjectMapper objectMapper;
+
+    public static synchronized Bioregistry getInstance() {
+        if (instance == null) {
+            instance = new Bioregistry();
+        }
+        return instance;
+    }
+
+    public Bioregistry() {
+        client = HttpClientBuilder.create().useSystemProperties().build();
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public String resolve(@Nonnull String id) {
+        String items[] = id.split(":", 2);
+        if (items.length == 2) {
+            return resolve(items[0], items[1]);
+        }
+        return null;
+    }
+
+    public String resolve(@Nonnull String prefix, @Nonnull String localIdentifier) {
+        Resource resource = getResource(prefix);
+        if (resource != null) {
+            return resource.formatURI(localIdentifier);
+        }
+        return null;
+    }
+
+    private Resource getResource(@Nonnull String prefix) {
+        if ( !cache.containsKey(prefix)) {
+            Resource resource = null;
+            HttpGet request = new HttpGet(String.format(API_ENDPOINT, prefix));
+            request.addHeader("Accept", "application/json");
+            try {
+                HttpResponse response = client.execute(request);
+                if ( response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    InputStream stream = response.getEntity().getContent();
+                    resource = objectMapper.readValue(stream, Resource.class);
+                }
+            } catch (IOException e ) {
+                logger.warn("Error when querying the bioregistry for '{}': {}", prefix, e.getMessage());
+            }
+            cache.put(prefix, resource);
+        }
+        return cache.get(prefix);
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/BioregistryLinkExtractor.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/BioregistryLinkExtractor.java
@@ -1,0 +1,32 @@
+package org.protege.editor.owl.model.bioregistry;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.protege.editor.owl.ui.renderer.LinkExtractor;
+import org.protege.editor.owl.ui.renderer.layout.HTTPLink;
+import org.protege.editor.owl.ui.renderer.layout.Link;
+
+/**
+ * Author: Damien Goutte-Gattat<br>
+ * University of Cambridge<br>
+ * FlyBase Group<br>
+ * Date: 03/04/2025
+ */
+public class BioregistryLinkExtractor implements LinkExtractor {
+
+    public static BioregistryLinkExtractor createExtractor() {
+        return new BioregistryLinkExtractor();
+    }
+
+    @Override
+    public Optional<Link> extractLink(String s) {
+        if ( s!= null) {
+            String uri = Bioregistry.getInstance().resolve(s);
+            if (uri != null) {
+                return Optional.of(new HTTPLink(URI.create(uri)));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/Resource.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/Resource.java
@@ -1,0 +1,36 @@
+package org.protege.editor.owl.model.bioregistry;
+
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Author: Damien Goutte-Gattat<br>
+ * University of Cambridge<br>
+ * FlyBase Group<br>
+ * Date: 03/04/2025
+ * <p>
+ * A resource within the Bioregistry. We only support the minimal set of fields required
+ * to be able to convert CURIEs into resolvable links.
+ * </p>
+ */
+public class Resource {
+
+    private String uriFormat;
+    private Pattern idPattern;
+
+    public Resource(@Nonnull @JsonProperty("pattern") String pattern,
+                    @Nonnull @JsonProperty("uri_format") String uriFormat) {
+        idPattern = Pattern.compile(pattern);
+        this.uriFormat = uriFormat;
+    }
+
+    public String formatURI(@Nonnull String id) {
+        if (idPattern.matcher(id).matches()) {
+            return uriFormat.replace("$1", id);
+        }
+        return null;
+    }
+}

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLAnnotationCellRenderer2.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/renderer/OWLAnnotationCellRenderer2.java
@@ -2,6 +2,7 @@ package org.protege.editor.owl.ui.renderer;
 
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.model.OWLModelManager;
+import org.protege.editor.owl.model.bioregistry.BioregistryLinkExtractor;
 import org.protege.editor.owl.model.entity.AnnotationPropertyComparator;
 import org.protege.editor.owl.model.identifiers.IdentifiersDotOrgLinkExtractor;
 import org.protege.editor.owl.model.obofoundry.OboFoundryLinkExtractor;
@@ -62,8 +63,9 @@ public class OWLAnnotationCellRenderer2 extends PageCellRenderer {
             WikipediaVersionedLinkExtractor.createExtractor(),
             DOILinkExtractor.createExtractor(),
             ORCIDLinkExtractor.createExtractor(),
-            IdentifiersDotOrgLinkExtractor.createExtractor(),
-            OboFoundryLinkExtractor.createLinkExtractor());
+            OboFoundryLinkExtractor.createLinkExtractor(),
+            BioregistryLinkExtractor.createExtractor(),
+            IdentifiersDotOrgLinkExtractor.createExtractor());
 
     public OWLAnnotationCellRenderer2(OWLEditorKit editorKit) {
         super();


### PR DESCRIPTION
This PR adds a new LinkExtractor that relies on the Bioregistry.io service.

Whenever we need to resolve an ID that looks like a CURIE ("prefix:local") with an as-yet-unseen prefix name, we look up that prefix name on the Bioregistry; if the prefix name is known to the registry, we cache (1) the pattern for the expected format of the local part, and (2) the template for constructing a resolvable URI. Then if the local identifier matches the Bioregistry-provided pattern, we apply the template to return the desired link.

The order in which the extractors are called is slightly modified so that we call:

* first, all the purely local extractors (that do not need to query an online service);
* then the OboFoundry-based extractor (which needs one remote query at initialisation time);
* then the Bioregistry-based extractor (which needs one remote query whenever a new prefix is encountered);
* and the Identifiers.org-based extractor (called only after the Bioregistry one because Identifiers.org is seemingly less up-to-date).

closes #1271