### PR TITLE
Allow line wrapping in deprecation wizard.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/deprecation/DeprecationReasonPage.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/deprecation/DeprecationReasonPage.java
@@ -36,6 +36,7 @@ public class DeprecationReasonPage extends AbstractOWLWizardPanel {
                                 "Please specify a reason that explains why this entity is to be deprecated.\n\n" +
                                 "The deprecated entity will be annotated with this reason so that consumers of this " +
                                 "ontology understand why the entity was deprecated.");
+        reasonTextArea.setLineWrap(true);
         contentPanel.add(reasonTextArea, BorderLayout.CENTER);
     }
 


### PR DESCRIPTION
In the 'Deprecate entity...' wizard, when asking for the reason for deprecation, allow line wrapping in the text area.

closes #1272