### PR TITLE
Add a 'Show deprecated' option to the search dialog.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderPreferences.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/find/OWLEntityFinderPreferences.java
@@ -27,6 +27,8 @@ public class OWLEntityFinderPreferences {
 
     public static final String IGNORE_WHITE_SPACE_KEY = "IGNORE_WHITE_SPACE_KEY";
 
+    public static final String SHOW_DEPRECATED_KEY = "SHOW_DEPRECATED";
+
 
     private static final boolean DEFAULT_CASE_SENSITIVE_VALUE = false;
 
@@ -42,6 +44,8 @@ public class OWLEntityFinderPreferences {
     private boolean wholeWords;
 
     private boolean ignoreWhiteSpace;
+
+    private boolean showDeprecated;
 
 
     private OWLEntityFinderPreferences() {
@@ -64,6 +68,7 @@ public class OWLEntityFinderPreferences {
         caseSensitive = prefs.getBoolean(CASE_SENSITIVE_KEY, DEFAULT_CASE_SENSITIVE_VALUE);
         wholeWords = prefs.getBoolean(WHOLE_WORDS_KEY, false);
         ignoreWhiteSpace = prefs.getBoolean(IGNORE_WHITE_SPACE_KEY, true);
+        showDeprecated = prefs.getBoolean(SHOW_DEPRECATED_KEY, true);
     }
 
 
@@ -102,6 +107,15 @@ public class OWLEntityFinderPreferences {
     public void setIgnoreWhiteSpace(boolean ignoreWhiteSpace) {
         this.ignoreWhiteSpace = ignoreWhiteSpace;
         getPreferences().putBoolean(IGNORE_WHITE_SPACE_KEY, ignoreWhiteSpace);
+    }
+
+    public boolean isShowDeprecated() {
+        return showDeprecated;
+    }
+
+    public void setShowDeprecated(boolean showDeprecated) {
+        this.showDeprecated = showDeprecated;
+        getPreferences().putBoolean(SHOW_DEPRECATED_KEY, showDeprecated);
     }
 
     public long getSearchDelay() {

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchOptions.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchOptions.java
@@ -25,6 +25,8 @@ public class SearchOptions {
 
     public static final boolean DEFAULT_SEARCH_IN_IRIS_SETTING = true;
 
+    public static final boolean DEFAULT_SHOW_DEPRECATED_ENTITIES = true;
+
 
     private final boolean useRegex;
 
@@ -44,6 +46,8 @@ public class SearchOptions {
 
     private final boolean searchInIRIs;
 
+    private final boolean showDeprecatedEntities;
+
 
     public SearchOptions() {
         useRegex = USE_REGEX_DEFAULT_SETTING;
@@ -54,6 +58,7 @@ public class SearchOptions {
         searchInAnnotationValues = DEFAULT_SEARCH_IN_ANNOTATION_VALUES_SETTING;
         searchInLogicalAxioms = DEFAULT_SEARCH_IN_LOGICAL_AXIOM_SETTING;
         searchInIRIs = DEFAULT_SEARCH_IN_IRIS_SETTING;
+        showDeprecatedEntities = DEFAULT_SHOW_DEPRECATED_ENTITIES;
     }
 
     private SearchOptions(Builder builder) {
@@ -65,6 +70,7 @@ public class SearchOptions {
         searchInAnnotationValues = builder.isSearchInAnnotationValues();
         searchInLogicalAxioms = builder.isSearchInLogicalAxioms();
         searchInIRIs = builder.isSearchInIRIs();
+        showDeprecatedEntities = builder.isShowDeprecatedEntities();
     }
 
     public boolean isUseRegex() {
@@ -99,6 +105,10 @@ public class SearchOptions {
         return searchInIRIs;
     }
 
+    public boolean isShowDeprecatedEntities() {
+        return showDeprecatedEntities;
+    }
+
     public static class Builder {
 
 
@@ -119,6 +129,8 @@ public class SearchOptions {
         private boolean searchInLogicalAxioms;
 
         private boolean searchInIRIs;
+
+        private boolean showDeprecatedEntities;
 
         public SearchOptions build() {
             return new SearchOptions(this);
@@ -156,6 +168,10 @@ public class SearchOptions {
             this.searchInIRIs = searchInIRIs;
         }
 
+        public void setShowDeprecatedEntities(boolean showDeprecatedEntities) {
+            this.showDeprecatedEntities = showDeprecatedEntities;
+        }
+
         public boolean isUseRegex() {
             return useRegex;
         }
@@ -186,6 +202,10 @@ public class SearchOptions {
 
         public boolean isSearchInIRIs() {
             return searchInIRIs;
+        }
+
+        public boolean isShowDeprecatedEntities() {
+            return showDeprecatedEntities;
         }
     }
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchOptionsPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchOptionsPanel.java
@@ -42,6 +42,8 @@ public class SearchOptionsPanel extends JPanel {
 
     private final JCheckBox searchInIRIs;
 
+    private final JCheckBox showDeprecatedCheckbox;
+
     private final JProgressBar searchProgressBar;
 
     private final JLabel searchProgressLabel = new JLabel();
@@ -89,7 +91,6 @@ public class SearchOptionsPanel extends JPanel {
         });
         topPanel.add(ignoreWhiteSpaceCheckbox);
 
-
         useRegexCheckBox = new JCheckBox(new AbstractAction("Regular expression") {
             public void actionPerformed(ActionEvent e) {
                 OWLEntityFinderPreferences.getInstance().setUseRegularExpressions(useRegexCheckBox.isSelected());
@@ -98,7 +99,6 @@ public class SearchOptionsPanel extends JPanel {
         });
         topPanel.add(useRegexCheckBox);
 
-
         showAllResultsCheckBox = new JCheckBox(new AbstractAction("Show all results") {
             public void actionPerformed(ActionEvent e) {
                 fireSearchResultsPresentationOptionChanged();
@@ -106,8 +106,16 @@ public class SearchOptionsPanel extends JPanel {
         });
         topPanel.add(showAllResultsCheckBox);
 
-        box.add(Box.createVerticalStrut(5));
+        showDeprecatedCheckbox = new JCheckBox(new AbstractAction("Show deprecated") {
+            public void actionPerformed(ActionEvent e) {
+                OWLEntityFinderPreferences.getInstance()
+                    .setShowDeprecated(showDeprecatedCheckbox.isSelected());
+                fireSearchResultsPresentationOptionChanged();
+            }
+        });
+        topPanel.add(showDeprecatedCheckbox);
 
+        box.add(Box.createVerticalStrut(5));
 
         JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 0));
         box.add(bottomPanel);
@@ -213,6 +221,10 @@ public class SearchOptionsPanel extends JPanel {
         return showAllResultsCheckBox.isSelected();
     }
 
+    public boolean isShowDeprecated() {
+        return showDeprecatedCheckbox.isSelected();
+    }
+
     private void fireSearchRequestOptionChanged() {
         for (SearchOptionsChangedListener listener : new ArrayList<>(listeners)) {
             listener.searchRequestOptionChanged();
@@ -233,6 +245,7 @@ public class SearchOptionsPanel extends JPanel {
         useRegexCheckBox.setSelected(prefs.isUseRegularExpressions());
         wholeWordsCheckbox.setSelected(prefs.isWholeWords());
         ignoreWhiteSpaceCheckbox.setSelected(prefs.isIgnoreWhiteSpace());
+        showDeprecatedCheckbox.setSelected(prefs.isShowDeprecated());
 
     }
 }

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchPanel.java
@@ -71,6 +71,8 @@ public class SearchPanel extends JPanel {
             }
         }));
         add(searchActionsPanel, BorderLayout.SOUTH);
+
+        updateSearchResultsPresentation();
     }
 
     private String getSearchString() {
@@ -161,6 +163,7 @@ public class SearchPanel extends JPanel {
     private void updateSearchResultsPresentation() {
         int categorySizeLimit = getCategoryLimit();
         searchResultsPanel.setCategorySizeLimit(categorySizeLimit);
+        searchResultsPanel.setShowDeprecated(searchOptionsPanel.isShowDeprecated());
     }
 
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchResultsPanel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchResultsPanel.java
@@ -145,6 +145,11 @@ public class SearchResultsPanel extends JPanel {
         refill();
     }
 
+    public void setShowDeprecated(boolean showDeprecated) {
+        this.model.setShowDeprecated(showDeprecated);
+        refill();
+    }
+
 
     public Optional<SearchResult> getSelectedSearchResult() {
         int selRow = resultsTable.getSelectedRow();

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchResultsTableModel.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/search/SearchResultsTableModel.java
@@ -10,6 +10,7 @@ import org.semanticweb.owlapi.model.OWLObject;
 
 import javax.annotation.Nullable;
 import javax.swing.table.AbstractTableModel;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,6 +37,8 @@ public class SearchResultsTableModel extends AbstractTableModel {
     private OWLEditorKit editorKit;
 
     private int categorySizeLimit = DEFAULT_CATEGORY_SIZE_LIMIT;
+
+    private boolean showDeprecated = SearchOptions.DEFAULT_SHOW_DEPRECATED_ENTITIES;
 
     private java.util.List<ResultsTableModelRow> rows = new ArrayList<>();
 
@@ -101,6 +104,13 @@ public class SearchResultsTableModel extends AbstractTableModel {
         }
     }
 
+    public void setShowDeprecated(boolean showDeprecated) {
+        if (showDeprecated != this.showDeprecated) {
+            this.showDeprecated = showDeprecated;
+            fireTableDataChanged();
+        }
+    }
+
     public void clearCategorySizeLimit() {
         if (categorySizeLimit != Integer.MAX_VALUE) {
             categorySizeLimit = Integer.MAX_VALUE;
@@ -117,6 +127,10 @@ public class SearchResultsTableModel extends AbstractTableModel {
             int count = 0;
             int categoryResultsCount = resultSet.getCategoryResultsCount(category);
             for (SearchResult searchResult : categoryResult) {
+                if (!showDeprecated
+                    && editorKit.getModelManager().isDeprecated(searchResult.getSubject())) {
+                    continue;
+                }
                 rows.add(new ResultsTableModelRow(searchResult, count, categoryResultsCount));
                 count++;
                 if (count == categorySizeLimit) {


### PR DESCRIPTION
This PR adds a new search option to show/hide deprecated entities from the search results. This only affects how search results are displayed, not how search is performed (that is, deprecated entities are found during a search regardless of the value of that option) -- this way, users can toggle the option to show or hide deprecated entities without triggering a new search.

closes #1273