### PR TITLE
Allow deprecating and merging entities from context menus

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/annotationproperty/OWLAnnotationPropertyHierarchyViewComponent.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/annotationproperty/OWLAnnotationPropertyHierarchyViewComponent.java
@@ -1,5 +1,6 @@
 package org.protege.editor.owl.ui.view.annotationproperty;
 
+import org.protege.editor.core.ui.menu.PopupMenuId;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.model.entity.OWLEntityCreationSet;
 import org.protege.editor.owl.model.hierarchy.OWLObjectHierarchyProvider;
@@ -59,6 +60,7 @@ public class OWLAnnotationPropertyHierarchyViewComponent extends AbstractOWLEnti
         }, "A", "B");
 
         addAction(new DeleteAnnotationPropertyAction(), "B", "A");
+        getTree().setPopupMenuId(new PopupMenuId("[AnnotationPropertyHierarchy]"));
     }
 
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/individual/OWLIndividualsByTypeViewComponent.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/ui/view/individual/OWLIndividualsByTypeViewComponent.java
@@ -1,7 +1,9 @@
 package org.protege.editor.owl.ui.view.individual;
 
 import com.google.common.collect.Sets;
+
 import org.protege.editor.core.ui.RefreshableComponent;
+import org.protege.editor.core.ui.menu.PopupMenuId;
 import org.protege.editor.core.ui.view.DisposableAction;
 import org.protege.editor.owl.model.entity.OWLEntityCreationSet;
 import org.protege.editor.owl.model.hierarchy.IndividualsByTypeHierarchyProvider;
@@ -85,6 +87,7 @@ public class OWLIndividualsByTypeViewComponent extends AbstractOWLSelectionViewC
             }
         });
         setupActions();
+        tree.setPopupMenuId(new PopupMenuId("[IndividualHierarchy]"));
     }
 
 

--- a/protege-editor-owl/src/main/resources/plugin.xml
+++ b/protege-editor-owl/src/main/resources/plugin.xml
@@ -1768,8 +1768,6 @@
         <editorKitId value="OWLEditorKit"/>
     </extension>
 
-
-
     <extension id="context.class.CreateSubHierarchy"
                point="org.protege.editor.core.application.EditorKitMenuAction">
         <name value="Add subclasses..."/>
@@ -1797,5 +1795,49 @@
         <editorKitId value="OWLEditorKit"/>
     </extension>
 
+    <extension id="context.class.DeprecateEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Deprecate..."/>
+        <class value="org.protege.editor.owl.ui.deprecation.DeprecateSelectedEntityAction"/>
+        <toolTip value="Deprecates the selected class"/>
+        <path value="[AssertedClassHierarchy]/SlotM-H"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.objectproperty.DeprecateEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Deprecate..."/>
+        <class value="org.protege.editor.owl.ui.deprecation.DeprecateSelectedEntityAction"/>
+        <toolTip value="Deprecates the selected object property"/>
+        <path value="[AssertedObjectPropertyHierarchy]/SlotE-A"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.annotationproperty.DeprecateEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Deprecate..."/>
+        <class value="org.protege.editor.owl.ui.deprecation.DeprecateSelectedEntityAction"/>
+        <toolTip value="Deprecates the selected class"/>
+        <path value="[AnnotationPropertyHierarchy]/SlotA-C"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.dataproperty.DeprecateEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Deprecate..."/>
+        <class value="org.protege.editor.owl.ui.deprecation.DeprecateSelectedEntityAction"/>
+        <toolTip value="Deprecate the selected data property"/>
+        <path value="[AssertedDataPropertyHierarchy]/SlotE-A"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.individual.DeprecateEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Deprecate..."/>
+        <class value="org.protege.editor.owl.ui.deprecation.DeprecateSelectedEntityAction"/>
+        <toolTip value="Deprecates the selected individual"/>
+        <path value="[IndividualHierarchy]/SlotA-A"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
 
 </plugin>

--- a/protege-editor-owl/src/main/resources/plugin.xml
+++ b/protege-editor-owl/src/main/resources/plugin.xml
@@ -1840,4 +1840,49 @@
         <editorKitId value="OWLEditorKit"/>
     </extension>
 
+    <extension id="context.class.MergeEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Merge into..."/>
+        <class value="org.protege.editor.owl.ui.merge.MergeEntitiesAction"/>
+        <toolTip value="Merges the selected class into another class"/>
+        <path value="[AssertedClassHierarchy]/SlotM-I"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.objectproperty.MergeEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Merge into..."/>
+        <class value="org.protege.editor.owl.ui.merge.MergeEntitiesAction"/>
+        <toolTip value="Merges the selected property into another property"/>
+        <path value="[AssertedObjectPropertyHierarchy]/SlotE-B"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.annotationproperty.MergeEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Merge into..."/>
+        <class value="org.protege.editor.owl.ui.merge.MergeEntitiesAction"/>
+        <toolTip value="Merges the selected property into another property"/>
+        <path value="[AnnotationPropertyHierarchy]/SlotA-D"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.dataproperty.MergeEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Merge into..."/>
+        <class value="org.protege.editor.owl.ui.merge.MergeEntitiesAction"/>
+        <toolTip value="Merges the selected property into another property"/>
+        <path value="[AssertedDataPropertyHierarchy]/SlotE-B"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
+    <extension id="context.individual.MergeEntity"
+               point="org.protege.editor.core.application.EditorKitMenuAction">
+        <name value="Merge into..."/>
+        <class value="org.protege.editor.owl.ui.merge.MergeEntitiesAction"/>
+        <toolTip value="Merges the selected indivdual into another individual"/>
+        <path value="[IndividualHierarchy]/SlotA-B"/>
+        <editorKitId value="OWLEditorKit"/>
+    </extension>
+
 </plugin>


### PR DESCRIPTION
This PR adds a _Deprecate..._ menu item in the context menu for the asserted class hierarchy view, the object, annotation, and data property hierarchy views, and the individuals-by-type view. The item triggers the same action as the _Edit/Deprecate entity..._ main menu item.

Similarly, it adds a _Merge..._ menu item to the same menus, which triggers the same action as the _Edit/Merge entity..._ main menu item.

closes #1228