### PR TITLE
Catch exception upon ill-formed extracted links.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/BioregistryLinkExtractor.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/bioregistry/BioregistryLinkExtractor.java
@@ -1,11 +1,14 @@
 package org.protege.editor.owl.model.bioregistry;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 import org.protege.editor.owl.ui.renderer.LinkExtractor;
 import org.protege.editor.owl.ui.renderer.layout.HTTPLink;
 import org.protege.editor.owl.ui.renderer.layout.Link;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Author: Damien Goutte-Gattat<br>
@@ -14,6 +17,8 @@ import org.protege.editor.owl.ui.renderer.layout.Link;
  * Date: 03/04/2025
  */
 public class BioregistryLinkExtractor implements LinkExtractor {
+
+    private static final Logger logger = LoggerFactory.getLogger(BioregistryLinkExtractor.class);
 
     public static BioregistryLinkExtractor createExtractor() {
         return new BioregistryLinkExtractor();
@@ -24,7 +29,11 @@ public class BioregistryLinkExtractor implements LinkExtractor {
         if ( s!= null) {
             String uri = Bioregistry.getInstance().resolve(s);
             if (uri != null) {
-                return Optional.of(new HTTPLink(URI.create(uri)));
+                try {
+                    return Optional.of(new HTTPLink(new URI(uri)));
+                } catch (URISyntaxException e) {
+                    logger.warn("Link extractor (Bioregistry) returned invalid URI: {}", e.getMessage());
+                }
             }
         }
         return Optional.empty();

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/identifiers/IdentifiersDotOrgLinkExtractor.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/identifiers/IdentifiersDotOrgLinkExtractor.java
@@ -3,8 +3,11 @@ package org.protege.editor.owl.model.identifiers;
 import org.protege.editor.owl.ui.renderer.LinkExtractor;
 import org.protege.editor.owl.ui.renderer.layout.HTTPLink;
 import org.protege.editor.owl.ui.renderer.layout.Link;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 /**
@@ -14,6 +17,8 @@ import java.util.Optional;
  */
 public class IdentifiersDotOrgLinkExtractor implements LinkExtractor {
 
+    private static final Logger logger = LoggerFactory.getLogger(IdentifiersDotOrgLinkExtractor.class);
+
     public static IdentifiersDotOrgLinkExtractor createExtractor() {
         return new IdentifiersDotOrgLinkExtractor();
     }
@@ -22,6 +27,13 @@ public class IdentifiersDotOrgLinkExtractor implements LinkExtractor {
     public Optional<Link> extractLink(String s) {
         IdentifiersDotOrg identifiersDotOrg = IdentifiersDotOrgManager.get();
         return identifiersDotOrg.getCollection(s)
-                .map(collection -> new HTTPLink(URI.create("http://identifiers.org/" + s)));
+                .flatMap(collection -> {
+                    try {
+                        return Optional.of(new HTTPLink(new URI("http://identifiers.org/" + s)));
+                    } catch (URISyntaxException e) {
+                        logger.warn("Link extractor (Identifiers.org) returned invalid URI: {}", e.getMessage());
+                        return Optional.empty();
+                    }
+                });
     }
 }


### PR DESCRIPTION
We cannot/should not rely on the link extractors to provide us with a necessarily valid URI. For example, both the Bioregistry and the Identifiers.org extractors will return an invalid URI if the original DOI happens to contain invalid characters (they do not automatically escape characters that are not allowed in a URI).

So we must be ready to catch a URISyntaxException and log a warning if we run into such a link, rather than let an uncaught exception pass through.