### PR TITLE
Fix Deserialization Vulnerability in deserialize Method

### DIFF
--- a/protege-editor-core/src/main/java/org/protege/editor/core/log/LogPreferences.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/log/LogPreferences.java
@@ -135,12 +135,13 @@ public class LogPreferences {
 	}
 
 	public static Object deserialize(byte[] bytes)
-			throws IOException, ClassNotFoundException {
-		try (ByteArrayInputStream b = new ByteArrayInputStream(bytes)) {
-			try (ObjectInputStream o = new ObjectInputStream(b)) {
-				return o.readObject();
-			}
-		}
+        throws IOException, ClassNotFoundException {
+	    try (ByteArrayInputStream b = new ByteArrayInputStream(bytes);
+	         ValidatingObjectInputStream o = new ValidatingObjectInputStream(b)) {
+	        // Only allow specific classes to be deserialized
+	        o.accept(LinkedList.class, LogMutation.class, HashMap.class, String.class);
+	        return o.readObject();
+	    }
 	}
 
 }


### PR DESCRIPTION
Description:
This PR addresses a critical security vulnerability in the deserialize method by properly implementing a secure deserialization pattern.

The original implementation used a standard ObjectInputStream without proper validation, which is susceptible to deserialization attacks. These attacks could potentially lead to remote code execution by deserializing malicious objects.

This vulnerability was originally found in apache/hadoop@5e2f433 corresponding to CVE-2022-25168 and fixed.

References:
1. apache/hadoop@5e2f433
2. https://nvd.nist.gov/vuln/detail/cve-2022-25168