### PR TITLE
Improve display of available ontologies in the ontology selector

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OWLWorkspace.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/OWLWorkspace.java
@@ -922,7 +922,12 @@ public class OWLWorkspace extends TabbedWorkspace implements SendErrorReportHand
 
     private void rebuildOntologyDropDown() {
         try {
-            TreeSet<OWLOntology> ts = new TreeSet<>(getOWLModelManager().getOWLObjectComparator());
+            Comparator<OWLOntology> comp = (o1, o2) -> {
+                String s1 = OWLOntologyCellRenderer.getOntologyLabelText(o1, getOWLModelManager());
+                String s2 = OWLOntologyCellRenderer.getOntologyLabelText(o2, getOWLModelManager());
+                return s1.compareTo(s2);
+            };
+            TreeSet<OWLOntology> ts = new TreeSet<>(comp);
             ts.addAll(getOWLModelManager().getOntologies());
             ontologiesList.setModel(new DefaultComboBoxModel<>(ts.toArray(new OWLOntology[ts.size()])));
             ontologiesList.setSelectedItem(getOWLModelManager().getActiveOntology());


### PR DESCRIPTION
When showing the available ontologies in the dropdown menu at the top of the main window:

1. if an ontology has ”display names” (`rdfs:title`, `dc:terms`) in several languages, try picking a name that matches the current language preferences set forth in the rendering settings;
2. sort the list of ontologies according to their display names.

closes #1246