### PR TITLE
update mokito-core (fix compile with javac-21)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+				<version>2.28.2</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/protege-editor-core/src/test/java/org/protege/editor/core/ui/menu/PopupMenuId_TestCase.java
+++ b/protege-editor-core/src/test/java/org/protege/editor/core/ui/menu/PopupMenuId_TestCase.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class PopupMenuId_TestCase {
 
     private PopupMenuId popupMenuId;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/ChangeListMinimizer_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/ChangeListMinimizer_TestCase.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 8 Jul 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ChangeListMinimizer_TestCase {
 
     private ChangeListMinimizer minimizer;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/annotation/AnnotationProvider_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/annotation/AnnotationProvider_TestCase.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 14 Jun 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AnnotationProvider_TestCase {
 
     private AnnotationProvider provider;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/axiom/ActiveOntologyLocationStrategy_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/axiom/ActiveOntologyLocationStrategy_TestCase.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Matthew Horridge, Stanford University, Bio-Medical Informatics Research Group, Date: 27/05/2014
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ActiveOntologyLocationStrategy_TestCase {
 
     @Mock

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/axiom/FreshActionStrategySelector_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/axiom/FreshActionStrategySelector_TestCase.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Matthew Horridge, Stanford University, Bio-Medical Informatics Research Group, Date: 28/05/2014
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class FreshActionStrategySelector_TestCase {
 
     @Mock

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/axiom/SubjectDefinitionLocationStrategy_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/axiom/SubjectDefinitionLocationStrategy_TestCase.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Matthew Horridge, Stanford University, Bio-Medical Informatics Research Group, Date: 27/05/2014
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SubjectDefinitionLocationStrategy_TestCase {
 
     @Mock
@@ -140,10 +140,6 @@ public class SubjectDefinitionLocationStrategy_TestCase {
 
         // OntologyB defines subject
         when(subjectDefinitionExtractor.getDefiningAxioms(subject, ontologyB))
-                .thenReturn(Collections.singleton(axiom));
-
-        // Ontology B defines subject
-        when(subjectDefinitionExtractor.getDefiningAxioms(subject, ontologyC))
                 .thenReturn(Collections.singleton(axiom));
 
         SubjectDefinitionLocationStrategy strategy = new SubjectDefinitionLocationStrategy(

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/deprecation/EntityDeprecator_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/deprecation/EntityDeprecator_TestCase.java
@@ -25,7 +25,7 @@ import static org.semanticweb.owlapi.apibinding.OWLFunctionalSyntaxFactory.*;
  * Stanford Center for Biomedical Informatics Research
  * 28 Aug 2017
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityDeprecator_TestCase {
 
     private static final String LABEL_PREFIX = "!label prefix!";
@@ -105,10 +105,6 @@ public class EntityDeprecator_TestCase {
         when(deprecationProfile.getPreservedAnnotationValuePrefix()).thenReturn(VALUE_PREFIX);
         when(deprecationProfile.getPreservedAnnotationValuePropertiesIris()).thenReturn(Collections.singleton(dataFactory.getRDFSSeeAlso().getIRI()));
         when(deprecationProfile.getDeprecatedClassParentIri()).thenReturn(Optional.empty());
-        when(deprecationProfile.getDeprecatedObjectPropertyParentIri()).thenReturn(Optional.empty());
-        when(deprecationProfile.getDeprecatedDataPropertyParentIri()).thenReturn(Optional.empty());
-        when(deprecationProfile.getDeprecatedAnnotationPropertyParentIri()).thenReturn(Optional.empty());
-        when(deprecationProfile.getDeprecatedIndividualParentClassIri()).thenReturn(Optional.empty());
         when(deprecationProfile.getDeprecationCode()).thenReturn(Optional.empty());
 
         DeprecateEntityInfo<OWLClass> info = new DeprecateEntityInfo<>(

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/entity/AnnotationPropertyComparator_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/entity/AnnotationPropertyComparator_TestCase.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 /**
  * @author Matthew Horridge, Stanford University, Bio-Medical Informatics Research Group, Date: 28/05/2014
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AnnotationPropertyComparator_TestCase {
 
     @Mock
@@ -58,7 +58,6 @@ public class AnnotationPropertyComparator_TestCase {
         when(propertyB.getIRI()).thenReturn(iriB);
         // Always return propertyA before propertyB with the delegate
         when(delegate.compare(propertyA, propertyB)).thenReturn(-1);
-        when(delegate.compare(propertyB, propertyA)).thenReturn(1);
     }
 
     @Test

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/entity/MarkdownRenderer_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/entity/MarkdownRenderer_TestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 29 Sep 2017
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class MarkdownRenderer_TestCase {
 
 

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/hierarchy/ObjectPropertyHierarchyProvider_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/hierarchy/ObjectPropertyHierarchyProvider_TestCase.java
@@ -24,7 +24,7 @@ import static org.semanticweb.owlapi.apibinding.OWLFunctionalSyntaxFactory.*;
  * Stanford Center for Biomedical Informatics Research
  * 25/01/16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ObjectPropertyHierarchyProvider_TestCase {
 
     private OWLObjectProperty superProperty;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/hierarchy/tabbed/CreateHierarchyChangeGenerator_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/hierarchy/tabbed/CreateHierarchyChangeGenerator_TestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 20 Sep 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CreateHierarchyChangeGenerator_TestCase<E extends OWLEntity> {
 
     @Mock

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/hierarchy/tabbed/Edge_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/hierarchy/tabbed/Edge_TestCase.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class Edge_TestCase {
 
     private Edge edge;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/inference/NoOpReasoner_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/inference/NoOpReasoner_TestCase.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 12 Aug 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class NoOpReasoner_TestCase {
 
     private NoOpReasoner reasoner;
@@ -46,8 +46,6 @@ public class NoOpReasoner_TestCase {
 
     @Before
     public void setUp() {
-        when(ontology.getOWLOntologyManager()).thenReturn(manager);
-        when(manager.getOWLDataFactory()).thenReturn(dataFactory);
         when(dataFactory.getOWLThing()).thenReturn(owlThing);
         when(dataFactory.getOWLNothing()).thenReturn(owlNothing);
         when(dataFactory.getOWLTopObjectProperty()).thenReturn(owlTopObjectProperty);
@@ -97,7 +95,6 @@ public class NoOpReasoner_TestCase {
     @Test
     public void shouldHandleNullManager_For_GetTopClassNode() {
         try {
-            when(ontology.getOWLOntologyManager()).thenReturn(null);
             reasoner.getTopClassNode();
         } catch (NullPointerException e) {
             fail("NullPointerException");
@@ -106,7 +103,6 @@ public class NoOpReasoner_TestCase {
     @Test
     public void shouldHandleNullManager_For_GetBottomClassNode() {
         try {
-            when(ontology.getOWLOntologyManager()).thenReturn(null);
             reasoner.getBottomClassNode();
         } catch (NullPointerException e) {
             fail("NullPointerException");
@@ -115,7 +111,6 @@ public class NoOpReasoner_TestCase {
     @Test
     public void shouldHandleNullManager_For_GetTopObjectPropertyNode() {
         try {
-            when(ontology.getOWLOntologyManager()).thenReturn(null);
             reasoner.getTopObjectPropertyNode();
         } catch (NullPointerException e) {
             fail("NullPointerException");
@@ -124,7 +119,6 @@ public class NoOpReasoner_TestCase {
     @Test
     public void shouldHandleNullManager_For_GetTopBottomObjectPropertyNode() {
         try {
-            when(ontology.getOWLOntologyManager()).thenReturn(null);
             reasoner.getBottomObjectPropertyNode();
         } catch (NullPointerException e) {
             fail("NullPointerException");
@@ -133,7 +127,6 @@ public class NoOpReasoner_TestCase {
     @Test
     public void shouldHandleNullManager_For_GetTopDataPropertyNode() {
         try {
-            when(ontology.getOWLOntologyManager()).thenReturn(null);
             reasoner.getTopDataPropertyNode();
         } catch (NullPointerException e) {
             fail("NullPointerException");
@@ -142,7 +135,6 @@ public class NoOpReasoner_TestCase {
     @Test
     public void shouldHandleNullManager_For_GetBottomObjectPropertyNode() {
         try {
-            when(ontology.getOWLOntologyManager()).thenReturn(null);
             reasoner.getBottomDataPropertyNode();
         } catch (NullPointerException e) {
             fail("NullPointerException");

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/merge/MergeEntitiesChangeListGenerator_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/merge/MergeEntitiesChangeListGenerator_TestCase.java
@@ -24,7 +24,7 @@ import static org.semanticweb.owlapi.apibinding.OWLFunctionalSyntaxFactory.Class
  * Stanford Center for Biomedical Informatics Research
  * 12 Mar 2018
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class MergeEntitiesChangeListGenerator_TestCase {
 
 

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/obofoundry/OboFoundryEntry_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/obofoundry/OboFoundryEntry_TestCase.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
  * Stanford Center for Biomedical Informatics Research
  * 2019-04-22
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OboFoundryEntry_TestCase {
 
     private static final String THE_ID = "The Id";

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/parser/OWLLiteralParser_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/parser/OWLLiteralParser_TestCase.java
@@ -16,7 +16,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 /**
  * @author Matthew Horridge, Stanford University, Bio-Medical Informatics Research Group, Date: 27/05/2014
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OWLLiteralParser_TestCase {
 
     private OWLDataFactory dataFactory;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/selection/OWLEntitySelectionModel_OWLClass_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/selection/OWLEntitySelectionModel_OWLClass_TestCase.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 10 Oct 2016
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OWLEntitySelectionModel_OWLClass_TestCase {
 
     private OWLEntitySelectionModel selectionModel;
@@ -40,14 +40,12 @@ public class OWLEntitySelectionModel_OWLClass_TestCase {
     @Test
     public void shouldReturnOptionalEmptyForNullObjectAndNullEntity() {
         when(delegate.getSelectedObject()).thenReturn(null);
-        when(delegate.getSelectedEntity()).thenReturn(null);
         assertThat(selectionModel.getSelectedClass(), is(Optional.empty()));
     }
 
     @Test
     public void shouldReturnOptionalEmptyForNullObjectAndOtherEntity() {
         when(delegate.getSelectedObject()).thenReturn(null);
-        when(delegate.getSelectedEntity()).thenReturn(mock(OWLEntity.class));
         assertThat(selectionModel.getSelectedClass(), is(Optional.empty()));
     }
 
@@ -68,14 +66,12 @@ public class OWLEntitySelectionModel_OWLClass_TestCase {
     @Test
     public void shouldReturnOptionalEmptyForNullEntityAndClass() {
         when(delegate.getSelectedObject()).thenReturn(null);
-        when(delegate.getSelectedEntity()).thenReturn(cls);
         assertThat(selectionModel.getSelectedClass(), is(Optional.empty()));
     }
 
     @Test
     public void shouldReturnOptionalOfClassForClassAndNullEntity() {
         when(delegate.getSelectedObject()).thenReturn(cls);
-        when(delegate.getSelectedEntity()).thenReturn(null);
         assertThat(selectionModel.getSelectedClass(), is(Optional.of(cls)));
     }
 
@@ -90,21 +86,18 @@ public class OWLEntitySelectionModel_OWLClass_TestCase {
     public void shouldReturnOptionalEmptyForOtherEntity() {
         OWLEntity otherEntity = mock(OWLEntity.class);
         when(delegate.getSelectedObject()).thenReturn(otherEntity);
-        when(delegate.getSelectedEntity()).thenReturn(otherEntity);
         assertThat(selectionModel.getSelectedClass(), is(Optional.empty()));
     }
 
     @Test
     public void shouldReturnOptionalOfClassForClassAndOtherEntity() {
         when(delegate.getSelectedObject()).thenReturn(cls);
-        when(delegate.getSelectedEntity()).thenReturn(mock(OWLEntity.class));
         assertThat(selectionModel.getSelectedClass(), is(Optional.of(cls)));
     }
 
     @Test
     public void shouldReturnOptionalOfClassForClassAndClass() {
         when(delegate.getSelectedObject()).thenReturn(cls);
-        when(delegate.getSelectedEntity()).thenReturn(cls);
         assertThat(selectionModel.getSelectedClass(), is(Optional.of(cls)));
     }
 

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/selection/OWLSelectionModelImpl_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/selection/OWLSelectionModelImpl_TestCase.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
  * Stanford Center for Biomedical Informatics Research
  * 5 Aug 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OWLSelectionModelImpl_TestCase {
 
     private OWLSelectionModelImpl selectionModel;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/selection/SelectionPlaneImpl_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/selection/SelectionPlaneImpl_TestCase.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
  * Stanford Center for Biomedical Informatics Research
  * 8 Aug 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SelectionPlaneImpl_TestCase {
 
     private SelectionPlaneImpl selectionPlane;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/DefaultUserNameProvider_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/DefaultUserNameProvider_TestCase.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.*;
  * Stanford Center for Biomedical Informatics Research
  * 31/01/16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultUserNameProvider_TestCase {
 
     public static final String USER_NAME = "Matthew";
@@ -53,14 +53,12 @@ public class DefaultUserNameProvider_TestCase {
     public void shouldReturnPreferencesManagerUserName() {
         Optional<String> userName = Optional.of(USER_NAME);
         when(preferencesManager.getUserName()).thenReturn(userName);
-        when(gitRepoUserNameProvider.getUserName()).thenReturn(Optional.empty());
         assertThat(provider.getUserName(), is(userName));
         verify(properties, never()).getProperty(anyString());
     }
 
     @Test
     public void shouldReturnPropertiesUserName() {
-        when(gitRepoUserNameProvider.getUserName()).thenReturn(Optional.empty());
         when(preferencesManager.getUserName()).thenReturn(Optional.empty());
         when(properties.getProperty("user.name")).thenReturn(USER_NAME);
         assertThat(provider.getUserName(), is(Optional.of(USER_NAME)));
@@ -70,7 +68,6 @@ public class DefaultUserNameProvider_TestCase {
 
     @Test
     public void shouldReturnEmpty() {
-        when(gitRepoUserNameProvider.getUserName()).thenReturn(Optional.empty());
         Optional<String> empty = Optional.<String>empty();
         when(preferencesManager.getUserName()).thenReturn(empty);
         when(properties.getProperty(anyString())).thenReturn(null);

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/OrcidPreferencesManager_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/OrcidPreferencesManager_TestCase.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
  * Stanford Center for Biomedical Informatics Research
  * 31/01/16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OrcidPreferencesManager_TestCase {
 
     public static final String USER_ORCID_KEY = "user.orcid";

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/UserNamePreferencesManager_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/user/UserNamePreferencesManager_TestCase.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
  * Stanford Center for Biomedical Informatics Research
  * 31/01/16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class UserNamePreferencesManager_TestCase {
 
     public static final String USER_NAME = "MatthewHorridge";

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/DefinedClassPredicate_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/DefinedClassPredicate_TestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 19 Sep 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefinedClassPredicate_TestCase {
 
     @Mock

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/ISO8601Formatter_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/ISO8601Formatter_TestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
  * Stanford Center for Biomedical Informatics Research
  * 31/01/16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ISO8601Formatter_TestCase {
 
 

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/LiteralLexicalValueReplacer_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/LiteralLexicalValueReplacer_TestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
  * Stanford Center for Biomedical Informatics Research
  * 23 Aug 2017
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class LiteralLexicalValueReplacer_TestCase {
 
     private static final String THE_LANG = "TheLang";
@@ -71,7 +71,6 @@ public class LiteralLexicalValueReplacer_TestCase {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void shouldThrowIndexOutOfBoundsExceptionOnInvalidPattern() {
-        when(literal.hasLang()).thenReturn(false);
         replacer.replaceLexicalValue(literal, "$1");
     }
 }

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/ReferenceFinder_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/util/ReferenceFinder_TestCase.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 20 May 16
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ReferenceFinder_TestCase {
 
     private ReferenceFinder referenceFinder;
@@ -61,7 +61,6 @@ public class ReferenceFinder_TestCase {
     public void shouldRetrieveAnnotationAssertionAxiomBySubjectReference() {
         when(ontology.getAxioms(AxiomType.ANNOTATION_ASSERTION)).thenReturn(Collections.singleton(annotationAssertionAxiom));
         when(annotationAssertionAxiom.getSubject()).thenReturn(iri);
-        when(annotationAssertionAxiom.getValue()).thenReturn(mock(IRI.class));
 
         ReferenceFinder.ReferenceSet referenceSet = getReferenceSet();
         assertThat(referenceSet.getReferencingAxioms(), hasItem(annotationAssertionAxiom));
@@ -80,7 +79,6 @@ public class ReferenceFinder_TestCase {
     @Test
     public void shouldRetrieveOntologyAnnotationsByValue() {
         when(ontology.getAnnotations()).thenReturn(Collections.singleton(ontologyAnnotation));
-        when(ontologyAnnotation.getProperty()).thenReturn(mock(OWLAnnotationProperty.class));
         when(ontologyAnnotation.getValue()).thenReturn(iri);
 
         ReferenceFinder.ReferenceSet referenceSet = getReferenceSet();

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/OWLPropertyAssertionRowComparator_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/OWLPropertyAssertionRowComparator_TestCase.java
@@ -13,7 +13,7 @@ import java.util.Comparator;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OWLPropertyAssertionRowComparator_TestCase {
 
     @Mock

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/breadcrumb/Breadcrumb_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/breadcrumb/Breadcrumb_TestCase.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class Breadcrumb_TestCase {
 
     private Breadcrumb breadcrumb;

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/renderer/OWLEntityRendererImpl_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/renderer/OWLEntityRendererImpl_TestCase.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Matthew Horridge, Stanford University, Bio-Medical Informatics Research Group, Date: 12/06/2014
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OWLEntityRendererImpl_TestCase {
 
     @Mock

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/renderer/RegExBasedLinkExtractor_TestCase.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/ui/renderer/RegExBasedLinkExtractor_TestCase.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class RegExBasedLinkExtractor_TestCase {
 
     private RegExBasedLinkExtractor regExBasedLinkExtractor;

--- a/protege-launcher/src/test/java/org/protege/osgi/framework/BundleInfo_TestCase.java
+++ b/protege-launcher/src/test/java/org/protege/osgi/framework/BundleInfo_TestCase.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class BundleInfo_TestCase {
 
     private BundleInfo bundleInfo;

--- a/protege-launcher/src/test/java/org/protege/osgi/framework/BundleSearchPath_TestCase.java
+++ b/protege-launcher/src/test/java/org/protege/osgi/framework/BundleSearchPath_TestCase.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
  * Stanford Center for Biomedical Informatics Research
  * 2019-01-25
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class BundleSearchPath_TestCase {
 
     private BundleInfo t0BundleInfo, t1BundleInfo;


### PR DESCRIPTION
switch to mokito v2.x . This fixes a compilation issue with modern Javac.. In particular, the code has been tested with javac-21 The update required the removal of code tests that were no longer needed