### PR TITLE
Avoid empty `xml:base` attribute in XML catalogs.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/library/folder/FolderGroupManager.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/library/folder/FolderGroupManager.java
@@ -76,7 +76,8 @@ public class FolderGroupManager extends CatalogEntryManager {
                                               boolean recursive,
                                               boolean autoUpdate,
                                               XmlBaseContext context) throws IOException {
-        return new GroupEntry(getIdString(ID_PREFIX, folder, recursive, autoUpdate), context, Prefer.PUBLIC, folder);
+        return new GroupEntry(getIdString(ID_PREFIX, folder, recursive, autoUpdate), context, Prefer.PUBLIC,
+                              folder.toString().length() > 0 ? folder : null);
     }
 
     protected static String getIdString(String idPrefix,


### PR DESCRIPTION
When creating a new Group in a XML catalog, check whether the URI representing the folder is empty. If it is, pass to the catalog a null object rather than an empty URI. This is to prevent the catalog writer from inserting a `xml:base=""` attribute when saving the catalog – such an empty `xml:base` makes no sense and is discouraged by the [XML Base specification](https://www.w3.org/TR/xmlbase/#same-document).

closes #1319