### PR TITLE
Do not fail the test suite for a remote server that is down.

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/identifiers/IdentifiersDotOrg.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/identifiers/IdentifiersDotOrg.java
@@ -37,6 +37,8 @@ public class IdentifiersDotOrg {
     @Nonnull
     private final ObjectMapper objectMapper;
 
+    private int lastHttpCode;
+
     private Multimap<String, IdoNamespace> byPrefix = HashMultimap.create();
 
     private IdentifiersDotOrg(@Nonnull HttpClient client,
@@ -68,6 +70,9 @@ public class IdentifiersDotOrg {
         });
     }
 
+    public int getLastStatus() {
+        return lastHttpCode;
+    }
 
     @Nonnull
     public Optional<IdoNamespace> getCollection(@Nonnull String compactId) {
@@ -89,7 +94,8 @@ public class IdentifiersDotOrg {
         HttpGet httpGet = new HttpGet(url);
         try {
             HttpResponse response = client.execute(httpGet);
-            if(response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+            lastHttpCode = response.getStatusLine().getStatusCode();
+            if(lastHttpCode == HttpStatus.SC_OK) {
                 InputStream contentInputStream = response.getEntity().getContent();
                 IdoResponse idoResponse = objectMapper.readValue(contentInputStream, IdoResponse.class);
                 JsonNode payload = idoResponse.getPayload();
@@ -117,7 +123,8 @@ public class IdentifiersDotOrg {
             while(url != null) {
                 HttpGet httpGet = new HttpGet(url);
                 HttpResponse response = client.execute(httpGet);
-                if(response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                lastHttpCode = response.getStatusLine().getStatusCode();
+                if(lastHttpCode == HttpStatus.SC_OK) {
                     InputStream contentInputStream = response.getEntity().getContent();
                     JsonNode idoResponse = objectMapper.readValue(contentInputStream, JsonNode.class);
                     // The namespaces list is an embedded resource that is paged

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/model/identifiers/IdentifiersDotOrg_IT.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/model/identifiers/IdentifiersDotOrg_IT.java
@@ -1,5 +1,7 @@
 package org.protege.editor.owl.model.identifiers;
 
+import org.apache.http.HttpStatus;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,6 +27,7 @@ public class IdentifiersDotOrg_IT {
     @Test
     public void shouldRetrieveNamespaces() {
         Optional<IdoNamespace> collection = identifiersDotOrg.getCollection("EFO:0008307");
+        Assume.assumeTrue(identifiersDotOrg.getLastStatus() == HttpStatus.SC_OK);
         assertThat(collection.isPresent(), is(true));
     }
 
@@ -38,6 +41,7 @@ public class IdentifiersDotOrg_IT {
     public void shouldResolveCompactId() {
         String compactId = "EFO:0008307";
         Optional<IdoResolvedResource> response = identifiersDotOrg.resolveCompactId(compactId);
+        Assume.assumeTrue(identifiersDotOrg.getLastStatus() == HttpStatus.SC_OK);
         assertThat(response.isPresent(), is(true));
         IdoResolvedResource theResponse = response.orElseThrow(RuntimeException::new);
         assertThat(theResponse.getCompactIdentifierResolvedUrl(), is(not(isEmptyString())));


### PR DESCRIPTION
The test suite may fail if the resolver at identifiers.org is down, because the test for IdentifiersDotOrg performs a live call to that server to ensure that we can resolve identifiers using that service.

The proper solution here would be to mock the identifiers.org service in the test suite, so that the test suite is completely independent of the remote service, but for now, we will at least detect whether the resolution failure is explained by a HTTP error, and if so we simply skip the test.