### PR TITLE
Update ID_PREFIX_PATTERN regex for better matching

### DIFF
--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/idrange/IdPolicyEntityCreationPreferencesUpdater.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/idrange/IdPolicyEntityCreationPreferencesUpdater.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class IdPolicyEntityCreationPreferencesUpdater {
 
-    private static final Pattern ID_PREFIX_PATTERN = Pattern.compile("(.+)([/#:])([A-Za-z0-9]+(_[A-Za-z0-9]).*)_$");
+    private static final Pattern ID_PREFIX_PATTERN = Pattern.compile("(.+)([/#:])([A-Za-z0-9]+(_[A-Za-z0-9]+).*)_$");
 
     private final static Logger logger = LoggerFactory.getLogger(IdPolicyEntityCreationPreferencesUpdater.class);
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/idrange/IdPolicyEntityCreationPreferencesUpdater.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/idrange/IdPolicyEntityCreationPreferencesUpdater.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class IdPolicyEntityCreationPreferencesUpdater {
 
-    private static final Pattern ID_PREFIX_PATTERN = Pattern.compile("(.+)([/#:])([A-Za-z0-9]+(_[A-Za-z0-9]+).*)_$");
+    private static final Pattern ID_PREFIX_PATTERN = Pattern.compile("(.+)([/#:])([A-Za-z0-9]+(_[A-Za-z0-9]+)*)_$");
 
     private final static Logger logger = LoggerFactory.getLogger(IdPolicyEntityCreationPreferencesUpdater.class);
 

--- a/protege-editor-owl/src/main/java/org/protege/editor/owl/model/idrange/IdPolicyEntityCreationPreferencesUpdater.java
+++ b/protege-editor-owl/src/main/java/org/protege/editor/owl/model/idrange/IdPolicyEntityCreationPreferencesUpdater.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class IdPolicyEntityCreationPreferencesUpdater {
 
-    private static final Pattern ID_PREFIX_PATTERN = Pattern.compile("(.+)([/#:])([A-Za-z0-9]+)_$");
+    private static final Pattern ID_PREFIX_PATTERN = Pattern.compile("(.+)([/#:])([A-Za-z0-9]+(_[A-Za-z0-9]).*)_$");
 
     private final static Logger logger = LoggerFactory.getLogger(IdPolicyEntityCreationPreferencesUpdater.class);
 


### PR DESCRIPTION
This fix should allow prefixes of the form APOLLO_SV_ or more generally any alphanumeric string followed by underscore followed by alphanumeric string followed by underscore.

Addresses #1338 