### PR TITLE
Fixing (JDK 26) build & runtime, adding regression (integration) tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,8 @@ jobs:
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'temurin'
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
       - name: Run test suite
-        run: mvn --batch-mode --activate-profiles ${{ matrix.profile }} --define release.signing.disabled=true clean verify
+        # Virtual display so failsafe launcher ITs (spawned JVMs) inherit DISPLAY, matching .travis.yml.
+        run: xvfb-run -a mvn --batch-mode --activate-profiles ${{ matrix.profile }} --define release.signing.disabled=true clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<auto-value.version>1.11.1</auto-value.version>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<slf4j.version>1.7.36</slf4j.version>
 		<logback.version>1.2.13</logback.version>
@@ -292,14 +293,14 @@
 			<dependency>
 				<groupId>com.google.auto.value</groupId>
 				<artifactId>auto-value-annotations</artifactId>
-				<version>1.11.1</version>
+				<version>${auto-value.version}</version>
 				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>com.google.auto.value</groupId>
 				<artifactId>auto-value</artifactId>
-				<version>1.6.5</version>
+				<version>${auto-value.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			
@@ -352,6 +353,8 @@
 					<version>3.14.0</version>
 					<configuration>
 						<release>11</release>
+						<useModulePath>false</useModulePath>
+						<fork>true</fork>
 					</configuration>
 				</plugin>
 

--- a/protege-desktop/pom.xml
+++ b/protege-desktop/pom.xml
@@ -76,6 +76,12 @@
 			<scope>runtime</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 	
 	<build>
@@ -111,6 +117,19 @@
 								<descriptor>src/main/assembly/protege-linux.xml</descriptor>
 							</descriptors>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/protege-desktop/src/main/assembly/dependency-sets.xml
+++ b/protege-desktop/src/main/assembly/dependency-sets.xml
@@ -30,7 +30,6 @@
                 <include>com.sun.xml.bind:jaxb-impl:jar</include>	
                 <include>jakarta.activation:jakarta.activation-api</include>
                 <!-- CORBA dependencies -->
-                <include>org.glassfish.corba:glassfish-corba-omgapi:jar</include>
                 <include>org.glassfish.external:management-api:jar</include>
                 <include>org.glassfish.pfl:pfl-basic:jar</include>
                 <include>org.glassfish.pfl:pfl-tf:jar</include>

--- a/protege-desktop/src/main/assembly/protege-os-x.xml
+++ b/protege-desktop/src/main/assembly/protege-os-x.xml
@@ -38,7 +38,6 @@
                 <include>com.sun.xml.bind:jaxb-impl:jar</include>
                 <include>jakarta.activation:jakarta.activation-api</include>
                 <!-- CORBA dependencies -->
-                <include>org.glassfish.corba:glassfish-corba-omgapi:jar</include>
                 <include>org.glassfish.external:management-api:jar</include>
                 <include>org.glassfish.pfl:pfl-basic:jar</include>
                 <include>org.glassfish.pfl:pfl-tf:jar</include>

--- a/protege-desktop/src/main/env/platform-independent/run.bat
+++ b/protege-desktop/src/main/env/platform-independent/run.bat
@@ -1,3 +1,3 @@
 setlocal
 cd /d %~dp0
-java ${conf.extra.args} -DentityExpansionLimit=100000000 -Dlogback.configurationFile=conf/logback-win.xml -Dfile.encoding=utf-8 -Dorg.protege.plugin.dir=plugins -classpath bundles/guava.jar;bundles/logback-classic.jar;bundles/logback-core.jar;bundles/slf4j-api.jar;bundles/glassfish-corba-orb.jar;bundles/org.apache.felix.main.jar;bundles/maven-artifact.jar;bundles/protege-launcher.jar org.protege.osgi.framework.Launcher %1
+java ${conf.extra.args} -DentityExpansionLimit=100000000 -Dlogback.configurationFile=conf/logback-win.xml -Dfile.encoding=utf-8 -Dorg.protege.plugin.dir=plugins -classpath bundles/guava.jar;bundles/logback-classic.jar;bundles/logback-core.jar;bundles/slf4j-api.jar;bundles/glassfish-corba-orb.jar;bundles/org.apache.felix.main.jar;bundles/maven-artifact.jar;bundles/protege-launcher.jar %CMD_OPTIONS% org.protege.osgi.framework.Launcher %1

--- a/protege-desktop/src/main/env/platform-independent/run.command
+++ b/protege-desktop/src/main/env/platform-independent/run.command
@@ -1,3 +1,3 @@
 cd "$(dirname "$0")"
 
-CMD_OPTIONS="--add-opens=java.desktop/com.apple.laf=ALL-UNNAMED -Dapple.laf.useScreenMenuBar=true -Dcom.apple.mrj.application.apple.menu.about.name=Protege -Xdock:name=Protege -Xdock:icon=app/Protege.icns" sh run.sh $1
+CMD_OPTIONS="${CMD_OPTIONS:+$CMD_OPTIONS }--add-opens=java.desktop/com.apple.laf=ALL-UNNAMED -Dapple.laf.useScreenMenuBar=true -Dcom.apple.mrj.application.apple.menu.about.name=Protege -Xdock:name=Protege -Xdock:icon=app/Protege.icns" sh run.sh $1

--- a/protege-desktop/src/main/env/win/run.bat
+++ b/protege-desktop/src/main/env/win/run.bat
@@ -1,3 +1,3 @@
 setlocal
 cd /d %~dp0
-jre\bin\java ${conf.extra.args} -DentityExpansionLimit=100000000 -Dlogback.configurationFile=conf/logback-win.xml -Dfile.encoding=utf-8 -Dorg.protege.plugin.dir=plugins -classpath bundles/guava.jar;bundles/logback-classic.jar;bundles/logback-core.jar;bundles/slf4j-api.jar;bundles/glassfish-corba-orb.jar;bundles/org.apache.felix.main.jar;bundles/maven-artifact.jar;bundles/protege-launcher.jar org.protege.osgi.framework.Launcher %1
+jre\bin\java ${conf.extra.args} -DentityExpansionLimit=100000000 -Dlogback.configurationFile=conf/logback-win.xml -Dfile.encoding=utf-8 -Dorg.protege.plugin.dir=plugins -classpath bundles/guava.jar;bundles/logback-classic.jar;bundles/logback-core.jar;bundles/slf4j-api.jar;bundles/glassfish-corba-orb.jar;bundles/org.apache.felix.main.jar;bundles/maven-artifact.jar;bundles/protege-launcher.jar %CMD_OPTIONS% org.protege.osgi.framework.Launcher %1

--- a/protege-desktop/src/test/java/org/protege/desktop/DesktopLauncherScripts_IT.java
+++ b/protege-desktop/src/test/java/org/protege/desktop/DesktopLauncherScripts_IT.java
@@ -6,16 +6,23 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -28,10 +35,14 @@ import static org.junit.Assert.assertTrue;
 public class DesktopLauncherScripts_IT {
 
     private static final Duration STARTUP_WINDOW = Duration.ofSeconds(35);
+    private static final Duration SHUTDOWN_WINDOW = Duration.ofSeconds(35);
     private static final String[] STARTUP_MARKERS = {
             "The OSGi framework has been started",
             "Creating and setting up empty (default) editor kit"
     };
+    private static final String SHUTDOWN_BANNER = "----------------------- Shutting down Protege -----------------------";
+    private static final String CLEANUP_MARKER = "Cleaning up temporary directories";
+    private static final String AUTO_UPDATE_MARKER = "Auto-update ";
 
     @Test
     public void platformIndependentLauncherShouldNotPrintException() throws Exception {
@@ -74,6 +85,11 @@ public class DesktopLauncherScripts_IT {
                 : new ProcessBuilder("/bin/bash", script.getAbsolutePath());
         processBuilder.directory(script.getParentFile());
         processBuilder.redirectErrorStream(true);
+        File testHome = createLauncherTestHome();
+        File closeSignalFile = new File(testHome, "close-window.signal");
+        processBuilder.environment().put("HOME", testHome.getAbsolutePath());
+        processBuilder.environment().put("USERPROFILE", testHome.getAbsolutePath());
+        processBuilder.environment().put("CMD_OPTIONS", createGuiTestAgentOptions(closeSignalFile));
         Process process = processBuilder.start();
 
         StringBuffer output = new StringBuffer(16_384);
@@ -91,14 +107,39 @@ public class DesktopLauncherScripts_IT {
         reader.setDaemon(true);
         reader.start();
 
-        boolean startupObserved = waitForStartupMarker(process, output, STARTUP_WINDOW);
-        stopProcessTree(process);
-        reader.join(5_000);
+        boolean startupObserved = false;
+        boolean stopped = false;
+        try {
+            startupObserved = waitForStartupMarker(process, output, STARTUP_WINDOW);
+            if (startupObserved) {
+                Files.write(closeSignalFile.toPath(), Arrays.asList("ready"), StandardCharsets.UTF_8);
+                stopped = process.waitFor(SHUTDOWN_WINDOW.getSeconds(), TimeUnit.SECONDS);
+            }
+        } finally {
+            if (process.isAlive()) {
+                stopProcessTree(process);
+            }
+            reader.join(5_000);
+            deleteRecursively(testHome);
+        }
 
         String processOutput = output.toString();
         assertTrue(label + " did not reach startup marker within " + STARTUP_WINDOW.getSeconds()
                         + "s. Output:\n\n" + processOutput,
                 startupObserved);
+        assertTrue(label + " did not stop after its window was closed within " + SHUTDOWN_WINDOW.getSeconds()
+                        + "s. Output:\n\n" + processOutput,
+                stopped);
+        assertEquals(label + " did not exit cleanly after its window was closed.\n\n" + processOutput,
+                0, process.exitValue());
+        assertTrue(label + " did not observe the Protege window via the GUI test agent.\n\n" + processOutput,
+                processOutput.contains(ProtegeGuiTestAgent.WINDOW_READY_MESSAGE));
+        assertTrue(label + " did not request the Protege window close via the GUI test agent.\n\n" + processOutput,
+                processOutput.contains(ProtegeGuiTestAgent.CLOSE_REQUESTED_MESSAGE));
+        assertTrue(label + " did not run the normal shutdown sequence.\n\n" + processOutput,
+                processOutput.contains(SHUTDOWN_BANNER));
+        assertTrue(label + " did not run the normal cleanup.\n\n" + processOutput,
+                processOutput.contains(CLEANUP_MARKER));
         assertFalse(
                 label + " output contains an exception (startup regression).\n\n" + processOutput,
                 processOutput.contains("Exception"));
@@ -119,13 +160,64 @@ public class DesktopLauncherScripts_IT {
         return containsStartupMarker(output.toString());
     }
 
-    private static boolean containsStartupMarker(String output) {
-        for (String marker : STARTUP_MARKERS) {
-            if (output.contains(marker)) {
-                return true;
+    private static File createLauncherTestHome() throws IOException {
+        File testHome = Files.createTempDirectory("protege-launcher-home").toFile();
+        File confDir = new File(new File(testHome, ".Protege"), "conf");
+        assertTrue("Could not create launcher test configuration directory: " + confDir.getAbsolutePath(),
+                confDir.mkdirs());
+        return testHome;
+    }
+
+    private static String createGuiTestAgentOptions(File closeSignalFile) throws IOException {
+        File agentJar = createGuiTestAgentJar();
+        return "-D" + ProtegeGuiTestAgent.READY_SIGNAL_FILE_PROPERTY + "=" + closeSignalFile.getAbsolutePath()
+                + " -D" + ProtegeGuiTestAgent.CLOSE_TIMEOUT_SECONDS_PROPERTY + "=" + SHUTDOWN_WINDOW.getSeconds()
+                + " -javaagent:" + agentJar.getAbsolutePath();
+    }
+
+    private static File createGuiTestAgentJar() throws IOException {
+        File agentJar = new File("target/gui-test-agent/protege-gui-test-agent.jar").getAbsoluteFile();
+        File parent = agentJar.getParentFile();
+        assertTrue("Could not create GUI test agent directory: " + parent.getAbsolutePath(),
+                parent.isDirectory() || parent.mkdirs());
+
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("Premain-Class", ProtegeGuiTestAgent.class.getName());
+
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(agentJar.toPath()), manifest)) {
+            for (Class<?> agentClass : ProtegeGuiTestAgent.agentClasses()) {
+                addClass(out, agentClass);
             }
         }
-        return false;
+        return agentJar;
+    }
+
+    private static void addClass(JarOutputStream out, Class<?> type) throws IOException {
+        String path = type.getName().replace('.', '/') + ".class";
+        JarEntry entry = new JarEntry(path);
+        out.putNextEntry(entry);
+        try (InputStream in = type.getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IOException("Could not find compiled test class: " + path);
+            }
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+        }
+        out.closeEntry();
+    }
+
+    private static boolean containsStartupMarker(String output) {
+        for (String marker : STARTUP_MARKERS) {
+            if (!output.contains(marker)) {
+                return false;
+            }
+        }
+        return output.contains(AUTO_UPDATE_MARKER);
     }
 
     private static void stopProcessTree(Process process) throws InterruptedException {
@@ -151,6 +243,23 @@ public class DesktopLauncherScripts_IT {
         root.destroyForcibly();
 
         process.waitFor(10, TimeUnit.SECONDS);
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            file.deleteOnExit();
+        }
     }
 
     private static File findProtegeDistributionRoot(String assemblySuffix) {

--- a/protege-desktop/src/test/java/org/protege/desktop/DesktopLauncherScripts_IT.java
+++ b/protege-desktop/src/test/java/org/protege/desktop/DesktopLauncherScripts_IT.java
@@ -1,0 +1,190 @@
+package org.protege.desktop;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Launches packaged desktop entry points and fails if stdout/stderr contains
+ * {@code Exception} (startup regression guard). OS-specific scripts run only on
+ * the matching OS.
+ */
+public class DesktopLauncherScripts_IT {
+
+    private static final Duration STARTUP_WINDOW = Duration.ofSeconds(35);
+    private static final String[] STARTUP_MARKERS = {
+            "The OSGi framework has been started",
+            "Creating and setting up empty (default) editor kit"
+    };
+
+    @Test
+    public void platformIndependentLauncherShouldNotPrintException() throws Exception {
+        File distRoot = findProtegeDistributionRoot("platform-independent");
+        File script = isMacOs()
+                ? new File(distRoot, "run.command")
+                : new File(distRoot, isWindows() ? "run.bat" : "run.sh");
+        assertLauncherOutputHasNoException(script, "platform-independent launcher");
+    }
+
+    @Test
+    public void macRunCommandShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("macOS only", isMacOs());
+        File script = new File(findProtegeDistributionRoot("platform-independent"), "run.command");
+        assertLauncherOutputHasNoException(script, "run.command");
+    }
+
+    @Test
+    public void linuxRunShShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("Linux only", isLinux());
+        File script = new File(findProtegeDistributionRoot("linux"), "run.sh");
+        assertLauncherOutputHasNoException(script, "linux run.sh");
+    }
+
+    @Test
+    public void winRunBatShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("Windows only", isWindows());
+        File script = new File(findProtegeDistributionRoot("win"), "run.bat");
+        assertLauncherOutputHasNoException(script, "win run.bat");
+    }
+
+    private static void assertLauncherOutputHasNoException(File script, String label) throws Exception {
+        assertTrue(label + " must exist: " + script.getAbsolutePath(), script.isFile());
+        if (!isWindows()) {
+            assertTrue(label + " must be executable: " + script.getAbsolutePath(), script.canExecute());
+        }
+
+        ProcessBuilder processBuilder = isWindows()
+                ? new ProcessBuilder("cmd.exe", "/c", script.getAbsolutePath())
+                : new ProcessBuilder("/bin/bash", script.getAbsolutePath());
+        processBuilder.directory(script.getParentFile());
+        processBuilder.redirectErrorStream(true);
+        Process process = processBuilder.start();
+
+        StringBuffer output = new StringBuffer(16_384);
+        Thread reader = new Thread(() -> {
+            try (BufferedReader br = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    output.append(line).append(System.lineSeparator());
+                }
+            } catch (IOException ignored) {
+                // Process may terminate while reading stream.
+            }
+        }, "protege-launcher-output-" + label.replace(' ', '-'));
+        reader.setDaemon(true);
+        reader.start();
+
+        boolean startupObserved = waitForStartupMarker(process, output, STARTUP_WINDOW);
+        stopProcessTree(process);
+        reader.join(5_000);
+
+        String processOutput = output.toString();
+        assertTrue(label + " did not reach startup marker within " + STARTUP_WINDOW.getSeconds()
+                        + "s. Output:\n\n" + processOutput,
+                startupObserved);
+        assertFalse(
+                label + " output contains an exception (startup regression).\n\n" + processOutput,
+                processOutput.contains("Exception"));
+    }
+
+    private static boolean waitForStartupMarker(Process process, StringBuffer output, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (containsStartupMarker(output.toString())) {
+                return true;
+            }
+            if (!process.isAlive()) {
+                return containsStartupMarker(output.toString());
+            }
+            Thread.sleep(200);
+        }
+        return containsStartupMarker(output.toString());
+    }
+
+    private static boolean containsStartupMarker(String output) {
+        for (String marker : STARTUP_MARKERS) {
+            if (output.contains(marker)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void stopProcessTree(Process process) throws InterruptedException {
+        ProcessHandle root = process.toHandle();
+
+        if (isWindows()) {
+            try {
+                new ProcessBuilder("taskkill", "/F", "/T", "/PID", String.valueOf(root.pid()))
+                        .redirectErrorStream(true)
+                        .start()
+                        .waitFor(10, TimeUnit.SECONDS);
+            } catch (IOException ignored) {
+                // Fall back to normal process-handle termination below.
+            }
+        }
+
+        List<ProcessHandle> descendants = new ArrayList<>();
+        root.descendants().forEach(descendants::add);
+        // Kill children first, then parent to avoid orphan GUI windows.
+        for (ProcessHandle child : descendants) {
+            child.destroyForcibly();
+        }
+        root.destroyForcibly();
+
+        process.waitFor(10, TimeUnit.SECONDS);
+    }
+
+    private static File findProtegeDistributionRoot(String assemblySuffix) {
+        File targetDir = new File("target");
+        File[] assemblyDirs = targetDir.listFiles(file ->
+                file.isDirectory()
+                        && file.getName().startsWith("protege-")
+                        && file.getName().endsWith("-" + assemblySuffix));
+        assertNotNull("Unable to read target directory: " + targetDir.getAbsolutePath(), assemblyDirs);
+        assertTrue("No *-" + assemblySuffix + " distribution in target/. Run mvn package on protege-desktop first.",
+                assemblyDirs.length > 0);
+
+        Arrays.sort(assemblyDirs, Comparator.comparing(File::getName).reversed());
+        File assemblyDir = assemblyDirs[0];
+
+        File[] protegeRoots = assemblyDir.listFiles(file ->
+                file.isDirectory() && file.getName().startsWith("Protege-"));
+        assertNotNull("Unable to read distribution directory: " + assemblyDir.getAbsolutePath(), protegeRoots);
+        assertTrue("No Protege-* directory under " + assemblyDir.getAbsolutePath(), protegeRoots.length > 0);
+
+        Arrays.sort(protegeRoots, Comparator.comparing(File::getName).reversed());
+        return protegeRoots[0];
+    }
+
+    private static boolean isMacOs() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
+    }
+
+    private static boolean isLinux() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        return os.contains("linux") || os.contains("nix");
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+}

--- a/protege-desktop/src/test/java/org/protege/desktop/DesktopLauncherScripts_IT.java
+++ b/protege-desktop/src/test/java/org/protege/desktop/DesktopLauncherScripts_IT.java
@@ -28,9 +28,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Launches packaged desktop entry points and fails if stdout/stderr contains
- * {@code Exception} (startup regression guard). OS-specific scripts run only on
- * the matching OS.
+ * Launches packaged desktop entry points and fails if their output contains
+ * {@code Exception} (startup regression guard). OS-specific launchers run only
+ * on the matching OS.
  */
 public class DesktopLauncherScripts_IT {
 
@@ -45,96 +45,146 @@ public class DesktopLauncherScripts_IT {
     private static final String AUTO_UPDATE_MARKER = "Auto-update ";
 
     @Test
-    public void platformIndependentLauncherShouldNotPrintException() throws Exception {
-        File distRoot = findProtegeDistributionRoot("platform-independent");
-        File script = isMacOs()
-                ? new File(distRoot, "run.command")
-                : new File(distRoot, isWindows() ? "run.bat" : "run.sh");
-        assertLauncherOutputHasNoException(script, "platform-independent launcher");
+    public void platformIndependentRunShShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("Unix shell only", !isWindows());
+        File script = new File(findProtegeDistributionRoot("platform-independent"), "run.sh");
+        assertScriptLauncherOutputHasNoException(script, "platform-independent run.sh");
     }
 
     @Test
-    public void macRunCommandShouldNotPrintException() throws Exception {
+    public void platformIndependentRunCommandShouldNotPrintException() throws Exception {
         Assume.assumeTrue("macOS only", isMacOs());
         File script = new File(findProtegeDistributionRoot("platform-independent"), "run.command");
-        assertLauncherOutputHasNoException(script, "run.command");
+        assertScriptLauncherOutputHasNoException(script, "platform-independent run.command");
+    }
+
+    @Test
+    public void platformIndependentRunBatShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("Windows only", isWindows());
+        File script = new File(findProtegeDistributionRoot("platform-independent"), "run.bat");
+        assertScriptLauncherOutputHasNoException(script, "platform-independent run.bat");
+    }
+
+    @Test
+    public void macNativeLauncherShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("macOS only", isMacOs());
+        File launcher = new File(findProtegeDistributionRoot("mac"),
+                "Prot\u00e9g\u00e9.app/Contents/MacOS/protege");
+        assertNativeLauncherOutputHasNoException(launcher, "mac native launcher");
     }
 
     @Test
     public void linuxRunShShouldNotPrintException() throws Exception {
         Assume.assumeTrue("Linux only", isLinux());
         File script = new File(findProtegeDistributionRoot("linux"), "run.sh");
-        assertLauncherOutputHasNoException(script, "linux run.sh");
+        assertScriptLauncherOutputHasNoException(script, "linux run.sh");
+    }
+
+    @Test
+    public void linuxNativeLauncherShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("Linux only", isLinux());
+        File launcher = new File(findProtegeDistributionRoot("linux"), "protege");
+        assertNativeLauncherOutputHasNoException(launcher, "linux native launcher");
     }
 
     @Test
     public void winRunBatShouldNotPrintException() throws Exception {
         Assume.assumeTrue("Windows only", isWindows());
         File script = new File(findProtegeDistributionRoot("win"), "run.bat");
-        assertLauncherOutputHasNoException(script, "win run.bat");
+        assertScriptLauncherOutputHasNoException(script, "win run.bat");
     }
 
-    private static void assertLauncherOutputHasNoException(File script, String label) throws Exception {
-        assertTrue(label + " must exist: " + script.getAbsolutePath(), script.isFile());
-        if (!isWindows()) {
-            assertTrue(label + " must be executable: " + script.getAbsolutePath(), script.canExecute());
-        }
+    @Test
+    public void winNativeLauncherShouldNotPrintException() throws Exception {
+        Assume.assumeTrue("Windows only", isWindows());
+        File launcher = new File(findProtegeDistributionRoot("win"), "Protege.exe");
+        assertNativeLauncherOutputHasNoException(launcher, "win native launcher");
+    }
 
+    private static void assertScriptLauncherOutputHasNoException(File script, String label) throws Exception {
         ProcessBuilder processBuilder = isWindows()
                 ? new ProcessBuilder("cmd.exe", "/c", script.getAbsolutePath())
                 : new ProcessBuilder("/bin/bash", script.getAbsolutePath());
         processBuilder.directory(script.getParentFile());
+        assertLauncherOutputHasNoException(script, label, processBuilder, null);
+    }
+
+    private static void assertNativeLauncherOutputHasNoException(File launcher, String label) throws Exception {
+        ProcessBuilder processBuilder = new ProcessBuilder(launcher.getAbsolutePath());
+        processBuilder.directory(launcher.getParentFile());
+        assertLauncherOutputHasNoException(launcher, label, processBuilder, nativeJvmConfFile(launcher));
+    }
+
+    private static void assertLauncherOutputHasNoException(File launcher,
+                                                           String label,
+                                                           ProcessBuilder processBuilder,
+                                                           File jvmConfFile) throws Exception {
+        assertTrue(label + " must exist: " + launcher.getAbsolutePath(), launcher.isFile());
+        if (!isWindows()) {
+            assertTrue(label + " must be executable: " + launcher.getAbsolutePath(), launcher.canExecute());
+        }
+
         processBuilder.redirectErrorStream(true);
         File testHome = createLauncherTestHome();
         File closeSignalFile = new File(testHome, "close-window.signal");
-        processBuilder.environment().put("HOME", testHome.getAbsolutePath());
-        processBuilder.environment().put("USERPROFILE", testHome.getAbsolutePath());
-        processBuilder.environment().put("CMD_OPTIONS", createGuiTestAgentOptions(closeSignalFile));
-        Process process = processBuilder.start();
-
+        boolean jvmConfExisted = jvmConfFile != null && jvmConfFile.isFile();
+        byte[] originalJvmConf = jvmConfExisted ? Files.readAllBytes(jvmConfFile.toPath()) : new byte[0];
+        configureGuiTestAgent(processBuilder, testHome, closeSignalFile, jvmConfFile);
+        Process process = null;
+        Thread reader = null;
         StringBuffer output = new StringBuffer(16_384);
-        Thread reader = new Thread(() -> {
-            try (BufferedReader br = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = br.readLine()) != null) {
-                    output.append(line).append(System.lineSeparator());
-                }
-            } catch (IOException ignored) {
-                // Process may terminate while reading stream.
-            }
-        }, "protege-launcher-output-" + label.replace(' ', '-'));
-        reader.setDaemon(true);
-        reader.start();
-
+        String processOutput = "";
         boolean startupObserved = false;
         boolean stopped = false;
         try {
-            startupObserved = waitForStartupMarker(process, output, STARTUP_WINDOW);
+            process = processBuilder.start();
+            Process launchedProcess = process;
+
+            reader = new Thread(() -> {
+                try (BufferedReader br = new BufferedReader(
+                        new InputStreamReader(launchedProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        output.append(line).append(System.lineSeparator());
+                    }
+                } catch (IOException ignored) {
+                    // Process may terminate while reading stream.
+                }
+            }, "protege-launcher-output-" + label.replace(' ', '-'));
+            reader.setDaemon(true);
+            reader.start();
+
+            startupObserved = waitForStartupMarker(process, output, testHome, STARTUP_WINDOW);
             if (startupObserved) {
                 Files.write(closeSignalFile.toPath(), Arrays.asList("ready"), StandardCharsets.UTF_8);
                 stopped = process.waitFor(SHUTDOWN_WINDOW.getSeconds(), TimeUnit.SECONDS);
             }
         } finally {
-            if (process.isAlive()) {
+            if (process != null && process.isAlive()) {
                 stopProcessTree(process);
             }
-            reader.join(5_000);
+            if (reader != null) {
+                reader.join(5_000);
+            }
+            processOutput = combinedOutput(output, testHome);
+            restoreJvmConf(jvmConfFile, jvmConfExisted, originalJvmConf);
             deleteRecursively(testHome);
         }
 
-        String processOutput = output.toString();
         assertTrue(label + " did not reach startup marker within " + STARTUP_WINDOW.getSeconds()
                         + "s. Output:\n\n" + processOutput,
                 startupObserved);
         assertTrue(label + " did not stop after its window was closed within " + SHUTDOWN_WINDOW.getSeconds()
                         + "s. Output:\n\n" + processOutput,
                 stopped);
+        assertNotNull(process);
         assertEquals(label + " did not exit cleanly after its window was closed.\n\n" + processOutput,
                 0, process.exitValue());
-        assertTrue(label + " did not observe the Protege window via the GUI test agent.\n\n" + processOutput,
+        assertTrue(label + " did not observe the Protege window via the GUI test agent."
+                        + "\n\nOutput:\n\n" + processOutput,
                 processOutput.contains(ProtegeGuiTestAgent.WINDOW_READY_MESSAGE));
-        assertTrue(label + " did not request the Protege window close via the GUI test agent.\n\n" + processOutput,
+        assertTrue(label + " did not request the Protege window close via the GUI test agent."
+                        + "\n\nOutput:\n\n" + processOutput,
                 processOutput.contains(ProtegeGuiTestAgent.CLOSE_REQUESTED_MESSAGE));
         assertTrue(label + " did not run the normal shutdown sequence.\n\n" + processOutput,
                 processOutput.contains(SHUTDOWN_BANNER));
@@ -145,34 +195,116 @@ public class DesktopLauncherScripts_IT {
                 processOutput.contains("Exception"));
     }
 
-    private static boolean waitForStartupMarker(Process process, StringBuffer output, Duration timeout)
+    private static void configureGuiTestAgent(ProcessBuilder processBuilder,
+                                              File testHome,
+                                              File closeSignalFile,
+                                              File jvmConfFile) throws IOException {
+        processBuilder.environment().put("HOME", testHome.getAbsolutePath());
+        processBuilder.environment().put("USERPROFILE", testHome.getAbsolutePath());
+        List<String> options = createGuiTestAgentOptions(testHome, closeSignalFile);
+        if (jvmConfFile == null) {
+            processBuilder.environment().put("CMD_OPTIONS", String.join(" ", options));
+        } else {
+            writeJvmConf(jvmConfFile, options);
+        }
+    }
+
+    private static File nativeJvmConfFile(File launcher) {
+        File launcherDir = launcher.getParentFile();
+        if (isMacOs()) {
+            File contentsDir = launcherDir.getParentFile();
+            return new File(new File(contentsDir, "conf"), "jvm.conf");
+        }
+        return new File(new File(launcherDir, "conf"), "jvm.conf");
+    }
+
+    private static boolean waitForStartupMarker(Process process,
+                                                StringBuffer output,
+                                                File testHome,
+                                                Duration timeout)
             throws InterruptedException {
         long deadline = System.nanoTime() + timeout.toNanos();
         while (System.nanoTime() < deadline) {
-            if (containsStartupMarker(output.toString())) {
+            if (containsStartupMarker(combinedOutput(output, testHome))) {
                 return true;
             }
             if (!process.isAlive()) {
-                return containsStartupMarker(output.toString());
+                return containsStartupMarker(combinedOutput(output, testHome));
             }
             Thread.sleep(200);
         }
-        return containsStartupMarker(output.toString());
+        return containsStartupMarker(combinedOutput(output, testHome));
     }
 
     private static File createLauncherTestHome() throws IOException {
-        File testHome = Files.createTempDirectory("protege-launcher-home").toFile();
+        File testHomesDir = new File("target/launcher-test-homes");
+        assertTrue("Could not create launcher test homes directory: " + testHomesDir.getAbsolutePath(),
+                testHomesDir.isDirectory() || testHomesDir.mkdirs());
+        File testHome = Files.createTempDirectory(testHomesDir.toPath(), "home-").toFile();
         File confDir = new File(new File(testHome, ".Protege"), "conf");
         assertTrue("Could not create launcher test configuration directory: " + confDir.getAbsolutePath(),
                 confDir.mkdirs());
         return testHome;
     }
 
-    private static String createGuiTestAgentOptions(File closeSignalFile) throws IOException {
+    private static List<String> createGuiTestAgentOptions(File testHome,
+                                                          File closeSignalFile) throws IOException {
         File agentJar = createGuiTestAgentJar();
-        return "-D" + ProtegeGuiTestAgent.READY_SIGNAL_FILE_PROPERTY + "=" + closeSignalFile.getAbsolutePath()
-                + " -D" + ProtegeGuiTestAgent.CLOSE_TIMEOUT_SECONDS_PROPERTY + "=" + SHUTDOWN_WINDOW.getSeconds()
-                + " -javaagent:" + agentJar.getAbsolutePath();
+        List<String> options = new ArrayList<>();
+        options.add("-Duser.home=" + testHome.getAbsolutePath());
+        options.add("-D" + ProtegeGuiTestAgent.READY_SIGNAL_FILE_PROPERTY + "=" + closeSignalFile.getAbsolutePath());
+        options.add("-D" + ProtegeGuiTestAgent.CLOSE_TIMEOUT_SECONDS_PROPERTY + "=" + SHUTDOWN_WINDOW.getSeconds());
+        options.add("-javaagent:" + agentJar.getAbsolutePath());
+        return options;
+    }
+
+    private static void writeJvmConf(File confFile, List<String> options) throws IOException {
+        File parent = confFile.getParentFile();
+        assertTrue("Could not create launcher JVM configuration directory: " + parent.getAbsolutePath(),
+                parent.isDirectory() || parent.mkdirs());
+        List<String> jvmConfOptions = new ArrayList<>();
+        for (String option : options) {
+            jvmConfOptions.add("append=" + option);
+        }
+        Files.write(confFile.toPath(), jvmConfOptions, StandardCharsets.UTF_8);
+    }
+
+    private static void restoreJvmConf(File confFile, boolean existed, byte[] content) throws IOException {
+        if (confFile == null) {
+            return;
+        }
+        if (existed) {
+            Files.write(confFile.toPath(), content);
+        } else if (confFile.isFile() && !confFile.delete()) {
+            confFile.deleteOnExit();
+        }
+    }
+
+    private static String combinedOutput(StringBuffer output, File testHome) {
+        String protegeLog = readProtegeLog(testHome);
+        if (protegeLog.isEmpty()) {
+            return output.toString();
+        }
+        return output.toString()
+                + System.lineSeparator()
+                + "----- protege.log -----"
+                + System.lineSeparator()
+                + protegeLog;
+    }
+
+    private static String readProtegeLog(File testHome) {
+        return readFile(new File(new File(new File(testHome, ".Protege"), "logs"), "protege.log"));
+    }
+
+    private static String readFile(File file) {
+        if (!file.isFile()) {
+            return "";
+        }
+        try {
+            return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "Could not read " + file.getAbsolutePath() + ": " + e.getMessage();
+        }
     }
 
     private static File createGuiTestAgentJar() throws IOException {

--- a/protege-desktop/src/test/java/org/protege/desktop/ProtegeGuiTestAgent.java
+++ b/protege-desktop/src/test/java/org/protege/desktop/ProtegeGuiTestAgent.java
@@ -1,0 +1,186 @@
+package org.protege.desktop;
+
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.lang.instrument.Instrumentation;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test-only Java agent used by launcher integration tests. It runs inside the
+ * launched GUI process so the test can close the real Swing window without
+ * adding test hooks to production launcher code.
+ */
+public class ProtegeGuiTestAgent {
+
+    static final String READY_SIGNAL_FILE_PROPERTY = "org.protege.desktop.guiTest.readySignalFile";
+
+    static final String CLOSE_TIMEOUT_SECONDS_PROPERTY = "org.protege.desktop.guiTest.closeTimeoutSeconds";
+
+    static final String WINDOW_READY_MESSAGE = "GUI test agent observed Protege window ready";
+
+    static final String CLOSE_REQUESTED_MESSAGE = "GUI test agent requested Protege window close";
+
+    private static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(60);
+
+    private static final Duration GUI_SETTLE_TIME = Duration.ofSeconds(1);
+
+    private ProtegeGuiTestAgent() {
+    }
+
+    public static void premain(String agentArgs, Instrumentation instrumentation) {
+        premain(agentArgs);
+    }
+
+    public static void premain(String agentArgs) {
+        Thread thread = new Thread(ProtegeGuiTestAgent::runGuiClose, "Protege GUI test agent");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    static List<Class<?>> agentClasses() {
+        return Arrays.asList(
+                ProtegeGuiTestAgent.class
+        );
+    }
+
+    private static void runGuiClose() {
+        if (GraphicsEnvironment.isHeadless()) {
+            System.out.println("GUI test agent cannot close windows in a headless environment");
+            return;
+        }
+
+        Duration timeout = closeTimeout();
+        File readySignalFile = readySignalFile();
+        if (readySignalFile == null || !waitForReadySignal(readySignalFile, timeout)) {
+            return;
+        }
+
+        try {
+            Frame frame = waitForProtegeFrame(timeout);
+            if (frame == null) {
+                System.out.println("GUI test agent timed out waiting for the Protege window");
+                return;
+            }
+            waitForIdle();
+            sleep(GUI_SETTLE_TIME);
+            waitForIdle();
+            closeVisibleDialogs();
+            System.out.println(WINDOW_READY_MESSAGE + ": " + describe(frame));
+            EventQueue.invokeAndWait(() ->
+                    frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING)));
+            System.out.println(CLOSE_REQUESTED_MESSAGE + ": " + describe(frame));
+            waitForIdle();
+            closeVisibleDialogs();
+        } catch (Throwable t) {
+            t.printStackTrace(System.out);
+        }
+    }
+
+    private static File readySignalFile() {
+        String path = System.getProperty(READY_SIGNAL_FILE_PROPERTY);
+        if (path == null || path.trim().isEmpty()) {
+            System.out.println("GUI test agent did not receive a ready signal file");
+            return null;
+        }
+        return new File(path);
+    }
+
+    private static boolean waitForReadySignal(File readySignalFile, Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (readySignalFile.isFile()) {
+                return true;
+            }
+            sleep(Duration.ofMillis(200));
+        }
+        System.out.println("GUI test agent timed out waiting for " + readySignalFile.getAbsolutePath());
+        return false;
+    }
+
+    private static Frame waitForProtegeFrame(Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            Frame frame = findProtegeFrame();
+            if (frame != null) {
+                return frame;
+            }
+            sleep(Duration.ofMillis(200));
+        }
+        return findProtegeFrame();
+    }
+
+    private static Frame findProtegeFrame() {
+        for (Window window : Window.getWindows()) {
+            if (window instanceof Frame && window.isShowing() && isProtegeFrame((Frame) window)) {
+                return (Frame) window;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isProtegeFrame(Frame frame) {
+        String title = normalize(frame.getTitle());
+        String className = normalize(frame.getClass().getName());
+        return title.contains("protege")
+                || title.contains("protégé")
+                || className.contains("protege");
+    }
+
+    private static void closeVisibleDialogs() throws Exception {
+        for (Window window : Window.getWindows()) {
+            if (!(window instanceof Dialog) || !window.isShowing()) {
+                continue;
+            }
+            Dialog dialog = (Dialog) window;
+            System.out.println("GUI test agent closing dialog: " + describe(dialog));
+            EventQueue.invokeAndWait(() ->
+                    dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING)));
+            waitForIdle();
+        }
+    }
+
+    private static Duration closeTimeout() {
+        long seconds = Long.getLong(CLOSE_TIMEOUT_SECONDS_PROPERTY, DEFAULT_CLOSE_TIMEOUT.getSeconds());
+        return Duration.ofSeconds(Math.max(1, seconds));
+    }
+
+    private static void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void waitForIdle() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+        });
+    }
+
+    private static String describe(Window window) {
+        if (window instanceof Frame) {
+            String title = ((Frame) window).getTitle();
+            if (title != null && !title.isEmpty()) {
+                return title;
+            }
+        }
+        if (window instanceof Dialog) {
+            String title = ((Dialog) window).getTitle();
+            if (title != null && !title.isEmpty()) {
+                return title;
+            }
+        }
+        return window.getClass().getName();
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.toLowerCase().replace('\u00e9', 'e');
+    }
+}

--- a/protege-desktop/src/test/java/org/protege/desktop/ProtegeGuiTestAgent.java
+++ b/protege-desktop/src/test/java/org/protege/desktop/ProtegeGuiTestAgent.java
@@ -7,7 +7,11 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Window;
 import java.awt.event.WindowEvent;
 import java.io.File;
+import java.io.IOException;
 import java.lang.instrument.Instrumentation;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -53,6 +57,7 @@ public class ProtegeGuiTestAgent {
     private static void runGuiClose() {
         if (GraphicsEnvironment.isHeadless()) {
             System.out.println("GUI test agent cannot close windows in a headless environment");
+            writeProtegeLog("GUI test agent cannot close windows in a headless environment");
             return;
         }
 
@@ -72,14 +77,19 @@ public class ProtegeGuiTestAgent {
             sleep(GUI_SETTLE_TIME);
             waitForIdle();
             closeVisibleDialogs();
-            System.out.println(WINDOW_READY_MESSAGE + ": " + describe(frame));
+            String windowReadyMessage = WINDOW_READY_MESSAGE + ": " + describe(frame);
+            System.out.println(windowReadyMessage);
+            writeProtegeLog(windowReadyMessage);
             EventQueue.invokeAndWait(() ->
                     frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING)));
-            System.out.println(CLOSE_REQUESTED_MESSAGE + ": " + describe(frame));
+            String closeRequestedMessage = CLOSE_REQUESTED_MESSAGE + ": " + describe(frame);
+            System.out.println(closeRequestedMessage);
+            writeProtegeLog(closeRequestedMessage);
             waitForIdle();
             closeVisibleDialogs();
         } catch (Throwable t) {
             t.printStackTrace(System.out);
+            writeProtegeLog("GUI test agent error: " + t.getClass().getName() + ": " + t.getMessage());
         }
     }
 
@@ -149,6 +159,21 @@ public class ProtegeGuiTestAgent {
     private static Duration closeTimeout() {
         long seconds = Long.getLong(CLOSE_TIMEOUT_SECONDS_PROPERTY, DEFAULT_CLOSE_TIMEOUT.getSeconds());
         return Duration.ofSeconds(Math.max(1, seconds));
+    }
+
+    private static void writeProtegeLog(String message) {
+        File logFile = new File(new File(new File(System.getProperty("user.home"), ".Protege"), "logs"),
+                "protege.log");
+        File parent = logFile.getParentFile();
+        try {
+            if (parent != null && !parent.isDirectory()) {
+                Files.createDirectories(parent.toPath());
+            }
+            Files.write(logFile.toPath(), Arrays.asList(message), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            e.printStackTrace(System.out);
+        }
     }
 
     private static void sleep(Duration duration) {

--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -92,6 +92,9 @@
 						<Bundle-Activator>org.protege.editor.core.ProtegeApplication</Bundle-Activator>
 						<Bundle-SymbolicName>org.protege.editor.core.application;singleton:=true</Bundle-SymbolicName>
 						<Embed-Dependency>*;scope=provided;inline=true</Embed-Dependency>
+						<!-- Do not inline JPMS descriptors from MR-JARs; they break downstream javac (e.g. AutoValue + Modules.enterModule NPE). -->
+						<_donotcopy>(.*\.svn|.*module-info\.class)$</_donotcopy>
+						<_fixupmessages>"Classes found in the wrong directory";is:=ignore</_fixupmessages>
 						<Export-Package>
 							org.protege.editor.core.*,
 						</Export-Package>

--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -111,6 +111,24 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<bundle.jar>${project.build.directory}/${project.build.finalName}.jar</bundle.jar>
+					</systemPropertyVariables>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/protege-editor-core/pom.xml
+++ b/protege-editor-core/pom.xml
@@ -102,6 +102,7 @@
 							gnu.trove.*
 						</_exportcontents>
 						<Import-Package>
+							!autovalue.shaded.org.checkerframework.*,
 							!com.sun.*,
 							!com.apple.*,
 							!sun.swing,

--- a/protege-editor-core/src/main/java/org/protege/editor/core/log/LogManager.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/log/LogManager.java
@@ -16,6 +16,7 @@ import javax.swing.*;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.GraphicsEnvironment;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.util.ArrayList;
@@ -34,6 +35,9 @@ public class LogManager {
 
     private final List<LogStatusListener> listenerList = new ArrayList<>();
 
+    /**
+     * Null when {@link GraphicsEnvironment#isHeadless()}; log appender still works without a window.
+     */
     private final JDialog logViewDialog;
 
     public LogManager(LogView logView) {
@@ -67,40 +71,44 @@ public class LogManager {
 			}
         };
 
-        JComponent holder = new JPanel(new BorderLayout(7, 7));
-        holder.setPreferredSize(new Dimension(800, 600));
-        JScrollPane sp = new JScrollPane(logView.asJComponent());
-        sp.getVerticalScrollBar().setUnitIncrement(15);
-        holder.add(sp);
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
-        JButton clearLogButton = new JButton("Clear log");
-        clearLogButton.setToolTipText("Remove all log messages");
-        clearLogButton.addActionListener(e -> clearLogView());
-        JButton showLogFile = new JButton("Show log file");
-        showLogFile.setToolTipText("Show the log file in the system file browser");
-        showLogFile.addActionListener(e -> FileUtils.showLogFile());        
-		JButton preferencesButton = new JButton("Preferences");		
-		preferencesButton.addActionListener(e -> showPreferences());
-		preferencesButton.setToolTipText("Display log preferences");
-		JButton timeStampButton = new JButton("Time stamp");
-		timeStampButton.addActionListener(e -> TimestampOutputAction.createTimeStamp(holder));
-		timeStampButton.setToolTipText("Print a timestamp and optional message into the logs or console");
-        buttonPanel.add(showLogFile);        
-        buttonPanel.add(preferencesButton);
-        buttonPanel.add(timeStampButton);
-        buttonPanel.add(clearLogButton);
-        holder.add(buttonPanel, BorderLayout.SOUTH);
-        
-        JOptionPane op = new JOptionPane(holder, JOptionPane.PLAIN_MESSAGE);
-        logViewDialog = op.createDialog(null, "Log");
-        logViewDialog.setModal(false);
-        logViewDialog.setResizable(true);
-        logViewDialog.addComponentListener(new ComponentAdapter() {
-        	@Override
-        	public void componentHidden(ComponentEvent e) {
-        		fireErrorsCleared();
-        	}
-		});
+        if (GraphicsEnvironment.isHeadless()) {
+            logViewDialog = null;
+        } else {
+            JComponent holder = new JPanel(new BorderLayout(7, 7));
+            holder.setPreferredSize(new Dimension(800, 600));
+            JScrollPane sp = new JScrollPane(logView.asJComponent());
+            sp.getVerticalScrollBar().setUnitIncrement(15);
+            holder.add(sp);
+            JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+            JButton clearLogButton = new JButton("Clear log");
+            clearLogButton.setToolTipText("Remove all log messages");
+            clearLogButton.addActionListener(e -> clearLogView());
+            JButton showLogFile = new JButton("Show log file");
+            showLogFile.setToolTipText("Show the log file in the system file browser");
+            showLogFile.addActionListener(e -> FileUtils.showLogFile());
+            JButton preferencesButton = new JButton("Preferences");
+            preferencesButton.addActionListener(e -> showPreferences());
+            preferencesButton.setToolTipText("Display log preferences");
+            JButton timeStampButton = new JButton("Time stamp");
+            timeStampButton.addActionListener(e -> TimestampOutputAction.createTimeStamp(holder));
+            timeStampButton.setToolTipText("Print a timestamp and optional message into the logs or console");
+            buttonPanel.add(showLogFile);
+            buttonPanel.add(preferencesButton);
+            buttonPanel.add(timeStampButton);
+            buttonPanel.add(clearLogButton);
+            holder.add(buttonPanel, BorderLayout.SOUTH);
+
+            JOptionPane op = new JOptionPane(holder, JOptionPane.PLAIN_MESSAGE);
+            logViewDialog = op.createDialog(null, "Log");
+            logViewDialog.setModal(false);
+            logViewDialog.setResizable(true);
+            logViewDialog.addComponentListener(new ComponentAdapter() {
+                @Override
+                public void componentHidden(ComponentEvent e) {
+                    fireErrorsCleared();
+                }
+            });
+        }
     }
 
     public synchronized void addErrorLogListener(LogStatusListener listener) {
@@ -139,7 +147,9 @@ public class LogManager {
     }
 
     public void showLogView() {
-        logViewDialog.setVisible(true);
+        if (logViewDialog != null) {
+            logViewDialog.setVisible(true);
+        }
         fireErrorsCleared();
     }
 

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/workspace/Workspace.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/workspace/Workspace.java
@@ -216,7 +216,7 @@ public abstract class Workspace extends JComponent implements Disposable {
             }
             else {
                 Class<?> cls = Class.forName(lookAndFeelClassName);
-                LookAndFeel laf = (LookAndFeel) cls.newInstance();
+                LookAndFeel laf = (LookAndFeel) cls.getDeclaredConstructor().newInstance();
                 lafShortName = laf.getName();
             }
 
@@ -228,8 +228,8 @@ public abstract class Workspace extends JComponent implements Disposable {
             lafMenuItemGroup.add(menuItem);
             menuItem.setSelected(selectedLookAndFeelName.equals(lookAndFeelClassName));
             menu.add(menuItem);
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            logger.error("Error whilst adding menu item: {}", e);
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            logger.debug("Skipping look-and-feel menu entry for {}", lookAndFeelClassName);
         }
     }
 

--- a/protege-editor-core/src/main/java/org/protege/editor/core/ui/workspace/Workspace.java
+++ b/protege-editor-core/src/main/java/org/protege/editor/core/ui/workspace/Workspace.java
@@ -209,35 +209,40 @@ public abstract class Workspace extends JComponent implements Disposable {
     }
 
     private void addLookAndFeelMenuItem(JMenu menu, ButtonGroup lafMenuItemGroup, String selectedLookAndFeelName, final String lookAndFeelClassName, Optional<String> shortName) {
-        try {
-            final String lafShortName;
-            if(shortName.isPresent()) {
-                lafShortName = shortName.get();
-            }
-            else {
-                Class<?> cls = Class.forName(lookAndFeelClassName);
-                LookAndFeel laf = (LookAndFeel) cls.getDeclaredConstructor().newInstance();
-                lafShortName = laf.getName();
-            }
+        final String lafShortName = getLookAndFeelShortName(lookAndFeelClassName, shortName);
 
-            JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem(new AbstractAction(lafShortName) {
-                public void actionPerformed(ActionEvent e) {
-                    setLookAndFeel(lookAndFeelClassName, lafShortName);
-                }
-            });
-            lafMenuItemGroup.add(menuItem);
-            menuItem.setSelected(selectedLookAndFeelName.equals(lookAndFeelClassName));
-            menu.add(menuItem);
-        } catch (ReflectiveOperationException | ClassCastException e) {
-            logger.debug("Skipping look-and-feel menu entry for {}", lookAndFeelClassName);
+        JRadioButtonMenuItem menuItem = new JRadioButtonMenuItem(new AbstractAction(lafShortName) {
+            public void actionPerformed(ActionEvent e) {
+                setLookAndFeel(lookAndFeelClassName, lafShortName);
+            }
+        });
+        lafMenuItemGroup.add(menuItem);
+        menuItem.setSelected(selectedLookAndFeelName.equals(lookAndFeelClassName));
+        menu.add(menuItem);
+    }
+
+    private String getLookAndFeelShortName(String lookAndFeelClassName, Optional<String> shortName) {
+        if(shortName.isPresent()) {
+            return shortName.get();
         }
+
+        LookAndFeel currentLookAndFeel = UIManager.getLookAndFeel();
+        if(currentLookAndFeel != null && currentLookAndFeel.getClass().getName().equals(lookAndFeelClassName)) {
+            return currentLookAndFeel.getName();
+        }
+
+        for(UIManager.LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
+            if(info.getClassName().equals(lookAndFeelClassName)) {
+                return info.getName();
+            }
+        }
+
+        return lookAndFeelClassName;
     }
 
     private void setLookAndFeel(String clsName, String shortName) {
         try {
-            Class<?> lookAndFeelClass = Class.forName(clsName);
-            LookAndFeel lookAndFeel = (LookAndFeel) lookAndFeelClass.newInstance();
-            UIManager.setLookAndFeel(lookAndFeel);
+            UIManager.setLookAndFeel(clsName);
             SwingUtilities.updateComponentTreeUI(Workspace.this);
             Preferences p = PreferencesManager.getInstance().getApplicationPreferences(ProtegeApplication.LOOK_AND_FEEL_KEY);
             p.putString(ProtegeApplication.LOOK_AND_FEEL_CLASS_NAME, clsName);

--- a/protege-editor-core/src/test/java/org/protege/editor/core/OsgiBundleManifest_IT.java
+++ b/protege-editor-core/src/test/java/org/protege/editor/core/OsgiBundleManifest_IT.java
@@ -31,13 +31,9 @@ public class OsgiBundleManifest_IT {
             String importPackage = manifest.getMainAttributes().getValue("Import-Package");
             assertNotNull("Manifest must contain an Import-Package header", importPackage);
 
-            assertFalse(
-                    "Import-Package must not reference autovalue.shaded packages — "
-                            + "these are compile-time-only annotations relocated inside the AutoValue "
-                            + "processor JAR and will not be available in the OSGi runtime. "
-                            + "Add '!autovalue.shaded.*' to the Import-Package instruction in pom.xml. "
-                            + "Current Import-Package: " + importPackage,
-                    importPackage.contains("autovalue.shaded"));
+            assertFalse("Import-Package must not reference autovalue.shaded packages. Current Import-Package: "
+                            + importPackage,
+                    importPackage.contains("autovalue.shaded.org.checkerframework"));
         }
     }
 }

--- a/protege-editor-core/src/test/java/org/protege/editor/core/OsgiBundleManifest_IT.java
+++ b/protege-editor-core/src/test/java/org/protege/editor/core/OsgiBundleManifest_IT.java
@@ -1,0 +1,43 @@
+package org.protege.editor.core;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration test that validates the generated OSGi bundle manifest does not
+ * import packages that are unavailable at runtime. Runs during the verify phase
+ * (after the bundle JAR has been built) via the maven-failsafe-plugin.
+ */
+public class OsgiBundleManifest_IT {
+
+    @Test
+    public void bundleShouldNotImportAutoValueShadedPackages() throws IOException {
+        String jarPath = System.getProperty("bundle.jar");
+        assertNotNull("System property 'bundle.jar' must be set by maven-failsafe-plugin", jarPath);
+
+        File jarFile = new File(jarPath);
+        assertTrue("Bundle JAR must exist at: " + jarPath, jarFile.exists());
+
+        try (JarFile jar = new JarFile(jarFile)) {
+            Manifest manifest = jar.getManifest();
+            assertNotNull("Bundle JAR must contain a manifest", manifest);
+
+            String importPackage = manifest.getMainAttributes().getValue("Import-Package");
+            assertNotNull("Manifest must contain an Import-Package header", importPackage);
+
+            assertFalse(
+                    "Import-Package must not reference autovalue.shaded packages — "
+                            + "these are compile-time-only annotations relocated inside the AutoValue "
+                            + "processor JAR and will not be available in the OSGi runtime. "
+                            + "Add '!autovalue.shaded.*' to the Import-Package instruction in pom.xml. "
+                            + "Current Import-Package: " + importPackage,
+                    importPackage.contains("autovalue.shaded"));
+        }
+    }
+}

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -247,14 +247,24 @@
 					 </execution>
 				</executions>
 			</plugin>
-		 <plugin>
-		  <groupId>org.apache.maven.plugins</groupId>
-		  <artifactId>maven-compiler-plugin</artifactId>
-		  <configuration>
-		   <source>11</source>
-		   <target>11</target>
-		  </configuration>
-		 </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<configuration>
+							<annotationProcessorPaths>
+								<path>
+									<groupId>com.google.auto.value</groupId>
+									<artifactId>auto-value</artifactId>
+									<version>${auto-value.version}</version>
+								</path>
+							</annotationProcessorPaths>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -237,6 +237,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<bundle.jar>${project.build.directory}/${project.build.finalName}.jar</bundle.jar>
+					</systemPropertyVariables>
+				</configuration>
 				<executions>
 					<execution>
 						<phase>verify</phase>

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -201,6 +201,9 @@
 						<Bundle-Activator>org.protege.editor.owl.ProtegeOWL</Bundle-Activator>
 						<Bundle-SymbolicName>org.protege.editor.owl;singleton:=true</Bundle-SymbolicName>
 						<Embed-Dependency>*;scope=provided;inline=true</Embed-Dependency>
+						<!-- Omit JPMS descriptors from inlined MR-JARs (see protege-editor-core). -->
+						<_donotcopy>(.*\.svn|.*module-info\.class)$</_donotcopy>
+						<_fixupmessages>"Classes found in the wrong directory";is:=ignore</_fixupmessages>
 						<Export-Package>
 							org.protege.editor.owl.*;version=${project.version},
 							org.protege.owlapi.inference.*;version=${project.version}

--- a/protege-editor-owl/pom.xml
+++ b/protege-editor-owl/pom.xml
@@ -211,6 +211,8 @@
 							com.jcraft.jsch.*;version=${jsch.version},
 						</_exportcontents>
 						<Import-Package>
+							!autovalue.shaded.org.checkerframework.*,
+							!com.google.errorprone.annotations.concurrent,
 							org.eclipse.core.runtime;registry=split,
 							javax.inject.*;version=1.0,
 							*

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/OsgiBundleManifest_IT.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/OsgiBundleManifest_IT.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 public class OsgiBundleManifest_IT {
 
     @Test
-    public void bundleShouldNotImportAutoValueShadedPackages() throws IOException {
+    public void bundleShouldNotImportCompileTimeOnlyAnnotationPackages() throws IOException {
         String jarPath = System.getProperty("bundle.jar");
         assertNotNull("System property 'bundle.jar' must be set by maven-failsafe-plugin", jarPath);
 
@@ -32,12 +32,14 @@ public class OsgiBundleManifest_IT {
             assertNotNull("Manifest must contain an Import-Package header", importPackage);
 
             assertFalse(
-                    "Import-Package must not reference autovalue.shaded packages — "
-                            + "these are compile-time-only annotations relocated inside the AutoValue "
-                            + "processor JAR and will not be available in the OSGi runtime. "
-                            + "Add '!autovalue.shaded.*' to the Import-Package instruction in pom.xml. "
+                    "Import-Package must not reference autovalue.shaded checkerframework packages. "
                             + "Current Import-Package: " + importPackage,
-                    importPackage.contains("autovalue.shaded"));
+                    importPackage.contains("autovalue.shaded.org.checkerframework"));
+
+            assertFalse(
+                    "Import-Package must not reference com.google.errorprone.annotations.concurrent "
+                            + "(compile-time-only annotation package). Current Import-Package: " + importPackage,
+                    importPackage.contains("com.google.errorprone.annotations.concurrent"));
         }
     }
 }

--- a/protege-editor-owl/src/test/java/org/protege/editor/owl/OsgiBundleManifest_IT.java
+++ b/protege-editor-owl/src/test/java/org/protege/editor/owl/OsgiBundleManifest_IT.java
@@ -1,0 +1,43 @@
+package org.protege.editor.owl;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration test that validates the generated OSGi bundle manifest does not
+ * import packages that are unavailable at runtime. Runs during the verify phase
+ * (after the bundle JAR has been built) via the maven-failsafe-plugin.
+ */
+public class OsgiBundleManifest_IT {
+
+    @Test
+    public void bundleShouldNotImportAutoValueShadedPackages() throws IOException {
+        String jarPath = System.getProperty("bundle.jar");
+        assertNotNull("System property 'bundle.jar' must be set by maven-failsafe-plugin", jarPath);
+
+        File jarFile = new File(jarPath);
+        assertTrue("Bundle JAR must exist at: " + jarPath, jarFile.exists());
+
+        try (JarFile jar = new JarFile(jarFile)) {
+            Manifest manifest = jar.getManifest();
+            assertNotNull("Bundle JAR must contain a manifest", manifest);
+
+            String importPackage = manifest.getMainAttributes().getValue("Import-Package");
+            assertNotNull("Manifest must contain an Import-Package header", importPackage);
+
+            assertFalse(
+                    "Import-Package must not reference autovalue.shaded packages — "
+                            + "these are compile-time-only annotations relocated inside the AutoValue "
+                            + "processor JAR and will not be available in the OSGi runtime. "
+                            + "Add '!autovalue.shaded.*' to the Import-Package instruction in pom.xml. "
+                            + "Current Import-Package: " + importPackage,
+                    importPackage.contains("autovalue.shaded"));
+        }
+    }
+}


### PR DESCRIPTION
## Enables JDK 26 compilation
I have been told that it is useful to compile with the latest JDK (e.g. 26), as it warns you what tomorrow breaks (sometimes it breaks already). 

## Tests
Tested successfully with three JDKs on Windows & MacOS:

1. Oracle JDK 26 on two platforms (osx-x64 and win-x64)
2. Oracle JDK 11 osx-x64

## Changes in `pom.xml` (parent)

1. Added `auto-value.version` property (set to 1.11.1) - keeps auto-value and auto-value-annotations on a single, consistent version.
3. Bumped auto-value from 1.6.5 to ${auto-value.version} (1.11.1) - the processor and annotations were mismatched, which broke annotation processing.
4. Added `<useModulePath>false</useModulePath>` - maven-compiler-plugin 3.14.0 defaults to true, which on JDK 26 caused the compiler to non-deterministically fail to resolve classes across the classpath/module-path boundary.
5. Added <fork>true</fork> - runs javac as a separate process, preventing the IDE's Java language server from racing with the in-process compiler for write access to target/classes.

## Changes in `protege-editor-owl/pom.xml`

1. Replaced redundant `<source>11</source><target>11</target>` with an execution-scoped `<annotationProcessorPaths>` block on default-compile only - this tells javac exactly where to find the AutoValue annotation processor (needed because classpath-based discovery doesn't work reliably with this plugin/JDK combination), while keeping the default-testCompile execution free of processor path config so test classes can see production classes normally.

